### PR TITLE
Added system_metric_collector tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.5)
 project(buildfarm_perf_tests)
 
+if(WIN32 OR APPLE OR ANDROID)
+  message(STATUS "buildfarm_perf_tests is only supported on Linux, skipping...")
+  return()
+endif()
+
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,42 @@
 cmake_minimum_required(VERSION 3.5)
-project(buildfarm_perf_tests LANGUAGES C)
+project(buildfarm_perf_tests)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(Boost REQUIRED COMPONENTS program_options)
+
+include_directories(include)
+
+add_executable(system_metric_collector
+  src/main_measurements.cpp
+  src/linux_cpu_process_measurement.cpp
+  src/linux_memory_process_measurement.cpp
+  src/linux_cpu_system_measurement.cpp
+  src/linux_memory_system_measurement.cpp
+  src/utilities/utilities.cpp
+)
+ament_target_dependencies(system_metric_collector
+  Boost
+)
+
+target_link_libraries(system_metric_collector
+  -lstdc++fs
+)
+
+install(TARGETS
+  system_metric_collector
+  DESTINATION
+  lib/${PROJECT_NAME}
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,6 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-find_package(Boost REQUIRED COMPONENTS program_options)
 
 include_directories(include)
 
@@ -23,9 +22,6 @@ add_executable(system_metric_collector
   src/linux_cpu_system_measurement.cpp
   src/linux_memory_system_measurement.cpp
   src/utilities/utilities.cpp
-)
-ament_target_dependencies(system_metric_collector
-  Boost
 )
 
 target_link_libraries(system_metric_collector

--- a/README.md
+++ b/README.md
@@ -63,3 +63,48 @@ colcon build --packages-select buildfarm_perf_tests --cmake-args -DPERF_TEST_MAX
 ![](img/lost_packets.png)
 ![](img/received_packets.png)
 ![](img/sent_packets.png)
+
+## System metrics collector tool
+
+This tool allows to create statistics based on the name of the process and arguments. This tool allows to collect the following statistics:
+
+ - CPU usage (%): This information is fetched from `/proc/stat`.
+ - CPU memory virtual, ResidentAnonymousMemory and physical: This information is fetched from `/proc/meminfo`.
+ - Process usage (%):  This information is fetched from `/proc/<pid/>stat`.
+ - Process memory: a) virtual, b) resident anonymous memory and c) physical:  This information is fetched from  `/proc/<pid/statm` and `/proc/<pid/status`.
+
+These are the argument to launch the tool:
+
+```
+ros2 run buildfarm_perf_tests system_metric_collector -h
+Options:
+  -h [ --help ]           Help screen
+  --timeout arg (=60)     Test duration
+  --log arg (=out.csv)    Log filename
+  --process_name arg      process_name
+  --process_arguments arg process_arguments
+```
+
+A general overview of what a typical run might do, for example:
+
+1. Start process under test. For example `perf_test`
+2. Launch `system_metrics_collector` using the argument  `--process_name` with the name of the process (in this case `perf_test`). You can also use the argument `--process_argument` to include one of the arguments of the `perf_test`, For example if you are running `perf_test` with `--roundtrip_mode` you can include in this option `Main` or `Relay` to identify each one of the processes.
+3. Finally `system_metrics_collector` will fetch the data from the files describe above. If you have include the option `--log` then the data it's recorded in the file otherwise the standard output will show the reading.
+
+### Examples
+
+Example 1:
+
+```bash
+ros2 run performance_test perf_test -c FastRTPS -t Array1k
+ros2 run buildfarm_perf_tests system_metric_collector --process_name perf_test
+```
+
+Example 2:
+
+```bash
+ros2 run performance_test perf_test -c FastRTPS -t Array1k --roundtrip_mode Relay
+ros2 run performance_test perf_test -c FastRTPS -t Array1k --roundtrip_mode Main
+ros2 run buildfarm_perf_tests system_metric_collector --process_name perf_test --process_argument Main
+ros2 run buildfarm_perf_tests system_metric_collector --process_name perf_test --process_argument Relay
+```

--- a/README.md
+++ b/README.md
@@ -81,30 +81,20 @@ Options:
   -h [ --help ]           Help screen
   --timeout arg (=60)     Test duration
   --log arg (=out.csv)    Log filename
-  --process_name arg      process_name
-  --process_arguments arg process_arguments
+  --process_pid arg      process pid
 ```
 
 A general overview of what a typical run might do, for example:
 
 1. Start process under test. For example `perf_test`
-2. Launch `system_metrics_collector` using the argument  `--process_name` with the name of the process (in this case `perf_test`). You can also use the argument `--process_argument` to include one of the arguments of the `perf_test`, For example if you are running `perf_test` with `--roundtrip_mode` you can include in this option `Main` or `Relay` to identify each one of the processes.
+2. Launch `system_metrics_collector` using the argument `--process_pid` with the pid of the process (in this case `perf_test`).
 3. Finally `system_metrics_collector` will fetch the data from the files describe above. If you have include the option `--log` then the data it's recorded in the file otherwise the standard output will show the reading.
 
 ### Examples
 
-Example 1:
-
 ```bash
-ros2 run performance_test perf_test -c FastRTPS -t Array1k
-ros2 run buildfarm_perf_tests system_metric_collector --process_name perf_test
-```
-
-Example 2:
-
-```bash
-ros2 run performance_test perf_test -c FastRTPS -t Array1k --roundtrip_mode Relay
-ros2 run performance_test perf_test -c FastRTPS -t Array1k --roundtrip_mode Main
-ros2 run buildfarm_perf_tests system_metric_collector --process_name perf_test --process_argument Main
-ros2 run buildfarm_perf_tests system_metric_collector --process_name perf_test --process_argument Relay
+ros2 run performance_test perf_test -c ROS2 -t Array1k &
+ps -e | grep perf_test
+  8621 pts/5    00:00:01 perf_test
+ros2 run buildfarm_perf_tests system_metric_collector -process_pid 8621
 ```

--- a/include/linux_cpu_process_measurement.hpp
+++ b/include/linux_cpu_process_measurement.hpp
@@ -1,0 +1,46 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef LINUX_CPU_PROCESS_MEASUREMENT_HPP_
+#define LINUX_CPU_PROCESS_MEASUREMENT_HPP_
+
+#include <unistd.h>
+#include <time.h>
+#include <linux/limits.h>
+#include <sys/times.h>
+
+#include <string>
+#include <vector>
+#include <fstream>
+#include <iostream>
+#include "utilities/utilities.hpp"
+
+class LinuxCPUProcessMeasurement
+{
+public:
+  explicit LinuxCPUProcessMeasurement(std::string pid);
+  double getCPUCurrentlyUsedByCurrentProcess();
+  int gettimesinceboot();
+  double getUptime();
+
+private:
+  void initCPUProcess();
+
+  int numProcessors_;
+  std::string pid_;
+
+  int16_t tickspersec_;
+  double cpu_usage_;
+};
+
+#endif  // LINUX_CPU_PROCESS_MEASUREMENT_HPP_

--- a/include/linux_cpu_system_measurement.hpp
+++ b/include/linux_cpu_system_measurement.hpp
@@ -1,0 +1,66 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef LINUX_CPU_SYSTEM_MEASUREMENT_HPP_
+#define LINUX_CPU_SYSTEM_MEASUREMENT_HPP_
+
+#include <unistd.h>
+#include <string>
+#include <vector>
+#include <fstream>
+#include <sstream>
+#include <chrono>
+#include <thread>
+#include <iostream>
+
+enum CPUStates
+{
+  S_USER = 0,
+  S_NICE,
+  S_SYSTEM,
+  S_IDLE,
+  S_IOWAIT,
+  S_IRQ,
+  S_SOFTIRQ,
+  S_STEAL,
+  S_GUEST,
+  S_GUEST_NICE,
+};
+
+const int NUM_CPU_STATES = 10;
+
+typedef struct CPUData
+{
+  std::string cpu;
+  size_t times[NUM_CPU_STATES];
+} CPUData;
+
+class LinuxCPUSystemMeasurement
+{
+public:
+  LinuxCPUSystemMeasurement();
+  void ReadStatsCPU(std::vector<CPUData> & entries);
+  float getCPUSystemCurrentlyUsed();
+
+private:
+  size_t GetIdleTime(const CPUData & e);
+  size_t GetActiveTime(const CPUData & e);
+  void initCPUProcess();
+  void makeReading();
+
+  std::vector<CPUData> entries1_;
+  std::vector<CPUData> entries2_;
+  int numProcessors_;
+};
+
+#endif  // LINUX_CPU_SYSTEM_MEASUREMENT_HPP_

--- a/include/linux_memory_process_measurement.hpp
+++ b/include/linux_memory_process_measurement.hpp
@@ -1,0 +1,57 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef LINUX_MEMORY_PROCESS_MEASUREMENT_HPP_
+#define LINUX_MEMORY_PROCESS_MEASUREMENT_HPP_
+
+#include <sys/types.h>
+#include <sys/sysinfo.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <string>
+#include <vector>
+#include <fstream>
+#include <iostream>
+#include "utilities/utilities.hpp"
+
+class LinuxMemoryProcessMeasurement
+{
+public:
+  explicit LinuxMemoryProcessMeasurement(std::string pid);
+  void makeReading();
+
+  inline double getTotalVirtualMem() {return this->totalVirtualMem_;}
+  inline double getVirtualMemUsed() {return this->virtualMemUsed_;}
+  inline double getVirtualMemUsedProcess() {return this->virtualMemUsedProcess_;}
+  inline double getTotalPhysMem() {return this->totalPhysMem_;}
+  inline double getPhysMemUsed() {return this->physMemUsed_;}
+  inline double getPhysMemUsedProcess() {return this->physMemUsedProcess_;}
+  inline double getResidentAnonymousMemory() {return this->residentAnonymousMemory_;}
+
+private:
+  int getResidentAnonymousMemoryCurrentlyUsedByCurrentProcess();
+  int getVirtualMemoryCurrentlyUsedByCurrentProcess();
+  int getPhysicalMemoryCurrentlyUsedByCurrentProcess();
+
+  double totalVirtualMem_;
+  double virtualMemUsed_;
+  double residentAnonymousMemory_;
+  double virtualMemUsedProcess_;
+  double totalPhysMem_;
+  double physMemUsed_;
+  double physMemUsedProcess_;
+  std::string pid_;
+};
+
+#endif  // LINUX_MEMORY_PROCESS_MEASUREMENT_HPP_

--- a/include/linux_memory_system_measurement.hpp
+++ b/include/linux_memory_system_measurement.hpp
@@ -1,0 +1,33 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef LINUX_MEMORY_SYSTEM_MEASUREMENT_HPP_
+#define LINUX_MEMORY_SYSTEM_MEASUREMENT_HPP_
+
+#include <unistd.h>
+#include <string>
+#include <vector>
+#include <fstream>
+#include <sstream>
+#include <limits>
+
+class LinuxMemorySystemMeasurement
+{
+public:
+  LinuxMemorySystemMeasurement();
+  double getTotalMemorySystem();
+  double getFreeMemorySystem();
+  double getAvailableMemorySystem();
+};
+
+#endif  // LINUX_MEMORY_SYSTEM_MEASUREMENT_HPP_

--- a/include/utilities/utilities.hpp
+++ b/include/utilities/utilities.hpp
@@ -1,0 +1,33 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef UTILITIES__UTILITIES_HPP_
+#define UTILITIES__UTILITIES_HPP_
+
+#include <vector>
+#include <string>
+#include <fstream>
+#include <iostream>
+
+#if __cplusplus == 201402L
+#include <experimental/filesystem>  // C++14
+namespace fs = std::experimental::filesystem;  // C++14
+#elif __cplusplus > 201402L
+#include <filesystem>  // C++17
+namespace fs = std::filesystem;
+#endif
+
+std::string getPIDByName(std::string process_name, std::string my_own_name, std::string arguments);
+std::vector<std::string> split(const std::string & s, char delimiter);
+
+#endif  // UTILITIES__UTILITIES_HPP_

--- a/src/linux_cpu_process_measurement.cpp
+++ b/src/linux_cpu_process_measurement.cpp
@@ -1,0 +1,140 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "linux_cpu_process_measurement.hpp"
+#include <string>
+#include <vector>
+
+LinuxCPUProcessMeasurement::LinuxCPUProcessMeasurement(std::string pid)
+: pid_(pid),
+  tickspersec_(sysconf(_SC_CLK_TCK)),
+  numProcessors_(0)
+{
+  initCPUProcess();
+}
+
+void LinuxCPUProcessMeasurement::initCPUProcess()
+{
+  std::string line;
+  std::ifstream myfile(std::string("/proc/cpuinfo"));
+  if (myfile.is_open()) {
+    while (std::getline(myfile, line) ) {
+      if (line.find("processor") != std::string::npos) {
+        this->numProcessors_++;
+      }
+    }
+  }
+  myfile.close();
+}
+
+int LinuxCPUProcessMeasurement::gettimesinceboot()
+{
+  double result = 0;
+  std::string line;
+  std::ifstream myfile(std::string("/proc/uptime"));
+  if (myfile.is_open()) {
+    while (std::getline(myfile, line) ) {
+      std::vector<std::string> tokens = split(line, ' ');
+      result = atof(tokens[0].c_str()) * tickspersec_ + atof(tokens[1].c_str());
+    }
+  }
+  myfile.close();
+  return result;
+}
+
+double LinuxCPUProcessMeasurement::getUptime()
+{
+  double uptime = 0;
+  std::string line;
+  std::ifstream myfile(std::string("/proc/uptime"));
+  if (myfile.is_open()) {
+    while (std::getline(myfile, line) ) {
+      std::vector<std::string> tokens = split(line, ' ');
+      uptime = atof(tokens[0].c_str());
+    }
+  }
+  myfile.close();
+  return uptime;
+}
+
+double LinuxCPUProcessMeasurement::getCPUCurrentlyUsedByCurrentProcess()
+{
+  int64_t pid;
+  std::string tcomm_string;
+  char state;
+
+  int64_t ppid;
+  int64_t pgid;
+  int64_t sid;
+  int64_t tty_nr;
+  int64_t tty_pgrp;
+
+  int64_t flags;
+  int64_t min_flt;
+  int64_t cmin_flt;
+  int64_t maj_flt;
+  int64_t cmaj_flt;
+  int64_t utime;
+  int64_t stimev;
+
+  int64_t cutime;
+  int64_t cstime;
+  int64_t priority;
+  int64_t nicev;
+  int64_t num_threads;
+  int64_t it_real_value;
+
+  uint64_t start_time;
+
+  int64_t vsize;
+  int64_t rss;
+  int64_t rsslim;
+  int64_t start_code;
+  int64_t end_code;
+  int64_t start_stack;
+  int64_t esp;
+  int64_t eip;
+
+  int64_t pending;
+  int64_t blocked;
+  int64_t sigign;
+  int64_t sigcatch;
+  int64_t wchan;
+  int64_t zero1;
+  int64_t zero2;
+  int64_t exit_signal;
+  int64_t cpu;
+  int64_t rt_priority;
+  int64_t policy;
+
+  double uptime = getUptime();
+
+  std::ifstream inputFile(std::string("/proc/") + this->pid_ + std::string("/stat"));
+
+  inputFile >> pid >> tcomm_string >> state >> ppid >> pgid >> sid >> tty_nr >>
+  tty_pgrp >> flags >> min_flt >> cmin_flt >> maj_flt >> cmaj_flt >>
+  utime >> stimev >> cutime >> cstime >> priority >> nicev >> num_threads >>
+  it_real_value >> start_time >> vsize >> rss >> rsslim >> start_code >>
+  end_code >> start_stack >> esp >> eip >> pending >> blocked >> sigign >>
+  sigcatch >> wchan >> zero1 >> zero2 >> exit_signal >> cpu >> rt_priority >>
+  policy;
+
+  double total_time = static_cast<double>(utime) + static_cast<double>(stimev);
+  total_time += static_cast<double>(cstime) + static_cast<double>(cutime);
+
+  double seconds = uptime - (start_time / this->tickspersec_);
+
+  this->cpu_usage_ = 100 * ((total_time / this->tickspersec_) / seconds) / this->numProcessors_;
+
+  return this->cpu_usage_;
+}

--- a/src/linux_cpu_system_measurement.cpp
+++ b/src/linux_cpu_system_measurement.cpp
@@ -21,7 +21,6 @@ LinuxCPUSystemMeasurement::LinuxCPUSystemMeasurement()
 {
   initCPUProcess();
   makeReading();
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
 }
 
 void LinuxCPUSystemMeasurement::initCPUProcess()

--- a/src/linux_cpu_system_measurement.cpp
+++ b/src/linux_cpu_system_measurement.cpp
@@ -1,0 +1,122 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "linux_cpu_system_measurement.hpp"
+
+#include <string>
+#include <vector>
+
+LinuxCPUSystemMeasurement::LinuxCPUSystemMeasurement()
+: numProcessors_(0)
+{
+  initCPUProcess();
+  makeReading();
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+}
+
+void LinuxCPUSystemMeasurement::initCPUProcess()
+{
+  std::string line;
+  std::ifstream myfile(std::string("/proc/cpuinfo"));
+  if (myfile.is_open()) {
+    while (std::getline(myfile, line) ) {
+      if (line.find("processor") != std::string::npos) {
+        this->numProcessors_++;
+      }
+    }
+  }
+  myfile.close();
+}
+
+size_t LinuxCPUSystemMeasurement::GetIdleTime(const CPUData & e)
+{
+  return e.times[S_IDLE] +
+         e.times[S_IOWAIT];
+}
+size_t LinuxCPUSystemMeasurement::GetActiveTime(const CPUData & e)
+{
+  return e.times[S_USER] +
+         e.times[S_NICE] +
+         e.times[S_SYSTEM] +
+         e.times[S_IRQ] +
+         e.times[S_SOFTIRQ] +
+         e.times[S_STEAL] +
+         e.times[S_GUEST] +
+         e.times[S_GUEST_NICE];
+}
+
+void LinuxCPUSystemMeasurement::makeReading()
+{
+  ReadStatsCPU(entries1_);
+}
+
+float LinuxCPUSystemMeasurement::getCPUSystemCurrentlyUsed()
+{
+  ReadStatsCPU(entries2_);
+
+  const size_t NUM_ENTRIES = entries1_.size();
+
+  double total = 0;
+
+  for (size_t i = 0; i < NUM_ENTRIES; ++i) {
+    const CPUData & e1 = entries1_[i];
+    const CPUData & e2 = entries2_[i];
+
+    const float ACTIVE_TIME = static_cast<float>(GetActiveTime(e2) - GetActiveTime(e1));
+    const float IDLE_TIME = static_cast<float>(GetIdleTime(e2) - GetIdleTime(e1));
+    const float TOTAL_TIME = ACTIVE_TIME + IDLE_TIME;
+
+    total += (100.f * ACTIVE_TIME / TOTAL_TIME);
+  }
+
+  entries1_ = entries2_;
+
+  return total / this->numProcessors_;
+}
+
+void LinuxCPUSystemMeasurement::ReadStatsCPU(std::vector<CPUData> & entries)
+{
+  entries.clear();
+  std::ifstream fileStat("/proc/stat");
+
+  std::string line;
+
+  const std::string STR_CPU("cpu");
+  const std::size_t LEN_STR_CPU = STR_CPU.size();
+  const std::string STR_TOT("tot");
+
+  while (std::getline(fileStat, line)) {
+    // cpu stats line found
+    if (!line.compare(0, LEN_STR_CPU, STR_CPU)) {
+      std::istringstream ss(line);
+
+      // store entry
+      entries.emplace_back(CPUData());
+      CPUData & entry = entries.back();
+
+      // read cpu label
+      ss >> entry.cpu;
+
+      if (entry.cpu.size() > LEN_STR_CPU) {
+        entry.cpu.erase(0, LEN_STR_CPU);
+      } else {
+        entry.cpu = STR_TOT;
+      }
+
+      // read times
+      for (int i = 0; i < NUM_CPU_STATES; ++i) {
+        ss >> entry.times[i];
+      }
+    }
+  }
+}

--- a/src/linux_memory_process_measurement.cpp
+++ b/src/linux_memory_process_measurement.cpp
@@ -1,0 +1,95 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "linux_memory_process_measurement.hpp"
+
+#include <string>
+#include <vector>
+
+LinuxMemoryProcessMeasurement::LinuxMemoryProcessMeasurement(std::string pid)
+: totalVirtualMem_(0),
+  virtualMemUsed_(0),
+  virtualMemUsedProcess_(0),
+  totalPhysMem_(0),
+  physMemUsed_(0),
+  physMemUsedProcess_(0),
+  pid_(pid)
+{
+}
+
+int LinuxMemoryProcessMeasurement::getVirtualMemoryCurrentlyUsedByCurrentProcess()
+{  // Note: this value is in KB!
+  std::ifstream inputFile(std::string("/proc/") + this->pid_ + std::string("/statm"));
+  int process_memory_used;
+  int process_memory_used_resident;
+  inputFile >> process_memory_used >> process_memory_used_resident;
+  return process_memory_used;
+}
+
+int LinuxMemoryProcessMeasurement::getResidentAnonymousMemoryCurrentlyUsedByCurrentProcess()
+{  // Note: this value is in KB!
+  std::ifstream inputFile(std::string("/proc/") + this->pid_ + std::string("/statm"));
+  int process_memory_used;
+  int process_memory_used_resident;
+  inputFile >> process_memory_used >> process_memory_used_resident;
+  return process_memory_used_resident;
+}
+
+int LinuxMemoryProcessMeasurement::getPhysicalMemoryCurrentlyUsedByCurrentProcess()
+{  // Note: this value is in KB!
+  std::string line;
+  std::ifstream myfile(std::string("/proc/") + this->pid_.c_str() + std::string("/status"));
+  if (myfile.is_open()) {
+    while (std::getline(myfile, line) ) {
+      if (line.find("VmRSS:") != std::string::npos) {
+        std::vector<std::string> tokens = split(line, ' ');
+        myfile.close();
+        return atoi(tokens[1].c_str());
+      }
+    }
+  }
+  return -1;
+}
+
+void LinuxMemoryProcessMeasurement::makeReading()
+{
+  struct sysinfo memInfo;
+  sysinfo(&memInfo);
+  int64_t totalVirtualMem = memInfo.totalram;
+  // Add other values in next statement to avoid int overflow on right hand side...
+  totalVirtualMem += memInfo.totalswap;
+  totalVirtualMem *= memInfo.mem_unit;
+  this->totalVirtualMem_ = totalVirtualMem / 1024.0 / 1024.0;  // Mb
+
+  int64_t virtualMemUsed = memInfo.totalram - memInfo.freeram;
+  // Add other values in next statement to avoid int overflow on right hand side...
+  virtualMemUsed += memInfo.totalswap - memInfo.freeswap;
+  virtualMemUsed *= memInfo.mem_unit;
+  this->virtualMemUsed_ = virtualMemUsed / 1024.0 / 1024.0;  // Mb
+
+  this->virtualMemUsedProcess_ = getVirtualMemoryCurrentlyUsedByCurrentProcess() / 1024.0;  // Mb
+
+  this->residentAnonymousMemory_ = getResidentAnonymousMemoryCurrentlyUsedByCurrentProcess() /
+    1024.0;                                                                                 // Mb
+
+  int64_t totalPhysMem = memInfo.totalram;
+  // Multiply in next statement to avoid int overflow on right hand side...
+  totalPhysMem *= memInfo.mem_unit;
+  this->totalPhysMem_ = totalPhysMem / 1024.0 / 1024.0;  // Mb
+
+  int64_t physMemUsed = memInfo.totalram - memInfo.freeram;
+  physMemUsed *= memInfo.mem_unit;
+  this->physMemUsed_ = physMemUsed / 1024.0 / 1024.0;
+
+  this->physMemUsedProcess_ = getPhysicalMemoryCurrentlyUsedByCurrentProcess() / 1024.0;  // Mb
+}

--- a/src/linux_memory_system_measurement.cpp
+++ b/src/linux_memory_system_measurement.cpp
@@ -1,0 +1,76 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "linux_memory_system_measurement.hpp"
+#include <string>
+#include <vector>
+#include <limits>
+
+LinuxMemorySystemMeasurement::LinuxMemorySystemMeasurement() {}
+
+double LinuxMemorySystemMeasurement::getTotalMemorySystem()
+{
+  std::string token;
+  std::ifstream file("/proc/meminfo");
+  while (file >> token) {
+    if (token == "MemTotal:") {
+      uint64_t mem;
+      if (file >> mem) {
+        return mem / 1024.0;       // Mb
+      } else {
+        return 0;
+      }
+    }
+    // ignore rest of the line
+    file.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+  }
+  return 0;
+}
+
+double LinuxMemorySystemMeasurement::getFreeMemorySystem()
+{
+  std::string token;
+  std::ifstream file("/proc/meminfo");
+  while (file >> token) {
+    if (token == "MemFree:") {
+      uint64_t mem;
+      if (file >> mem) {
+        return mem / 1024.0;       // Mb
+      } else {
+        return 0;
+      }
+    }
+    // ignore rest of the line
+    file.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+  }
+  return 0;
+}
+
+double LinuxMemorySystemMeasurement::getAvailableMemorySystem()
+{
+  std::string token;
+  std::ifstream file("/proc/meminfo");
+  while (file >> token) {
+    if (token == "MemAvailable:") {
+      uint64_t mem;
+      if (file >> mem) {
+        return mem / 1024.0;       // Mb
+      } else {
+        return 0;
+      }
+    }
+    // ignore rest of the line
+    file.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+  }
+  return 0;
+}

--- a/src/main_measurements.cpp
+++ b/src/main_measurements.cpp
@@ -22,13 +22,13 @@
 
 void show_usage()
 {
-    std::cerr << "Usage: system_metric_collector [OPTION [ARG]] ...\n"
-              << "Options:\n"
-              << "\t-h,--help\t\tShow this help message\n"
-              << "\t--timeout arg (=60)\tTest duration\n"
-              << "\t--log arg (=out.csv)\tLog filename\n"
-              << "\t--process_pid arg\tProcess PID\n"
-              << std::endl;
+  std::cerr << "Usage: system_metric_collector [OPTION [ARG]] ...\n" <<
+    "Options:\n" <<
+    "\t-h,--help\t\tShow this help message\n" <<
+    "\t--timeout arg (=60)\tTest duration\n" <<
+    "\t--log arg (=out.csv)\tLog filename\n" <<
+    "\t--process_pid arg\tProcess PID\n" <<
+    std::endl;
 }
 
 int main(int argc, char * argv[])
@@ -40,36 +40,36 @@ int main(int argc, char * argv[])
   for (int i = 1; i < argc; ++i) {
     std::string arg = argv[i];
     if ((arg == "-h") || (arg == "--help")) {
-        show_usage();
-        return 0;
+      show_usage();
+      return 0;
     } else if (arg == "--process_pid") {
-        if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-            process_pid = argv[++i]; // Increment 'i' so we don't get the argument as the next argv[i].
-        } else { // Uh-oh, there was no argument to the destination option.
-            std::cerr << "--process_pid option requires one argument." << std::endl;
-            return 1;
-        }
+      if (i + 1 < argc) {   // Make sure we aren't at the end of argv!
+        process_pid = argv[++i];     // Increment 'i' so we don't get the argument as the next argv[i].
+      } else {   // Uh-oh, there was no argument to the destination option.
+        std::cerr << "--process_pid option requires one argument." << std::endl;
+        return 1;
+      }
     } else if (arg == "--timeout") {
-        if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-          timeout = std::atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
-        } else { // Uh-oh, there was no argument to the destination option.
-            std::cerr << "--timeout option requires one argument." << std::endl;
-            return 1;
-        }
+      if (i + 1 < argc) {   // Make sure we aren't at the end of argv!
+        timeout = std::atoi(argv[++i]);   // Increment 'i' so we don't get the argument as the next argv[i].
+      } else {   // Uh-oh, there was no argument to the destination option.
+        std::cerr << "--timeout option requires one argument." << std::endl;
+        return 1;
+      }
     } else if (arg == "--log") {
-        if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-          std::string filename = argv[++i];
-          m_os.open(filename, std::ofstream::out);
-          std::cout << "file_name " << filename << std::endl;
-          if (m_os.is_open()) {
-            m_os << "T_experiment" << ",cpu_usage (%)" << ",virtual memory (Mb)" <<
-              ",physical memory (Mb)" << ",resident anonymous memory (Mb)" <<
-              ",system_cpu_usage (%)" << ",system virtual memory (Mb)" << std::endl;
-          }
-        } else { // Uh-oh, there was no argument to the destination option.
-            std::cerr << "--log option requires one argument." << std::endl;
-            return 1;
+      if (i + 1 < argc) {   // Make sure we aren't at the end of argv!
+        std::string filename = argv[++i];
+        m_os.open(filename, std::ofstream::out);
+        std::cout << "file_name " << filename << std::endl;
+        if (m_os.is_open()) {
+          m_os << "T_experiment" << ",cpu_usage (%)" << ",virtual memory (Mb)" <<
+            ",physical memory (Mb)" << ",resident anonymous memory (Mb)" <<
+            ",system_cpu_usage (%)" << ",system virtual memory (Mb)" << std::endl;
         }
+      } else {   // Uh-oh, there was no argument to the destination option.
+        std::cerr << "--log option requires one argument." << std::endl;
+        return 1;
+      }
     }
   }
 

--- a/src/main_measurements.cpp
+++ b/src/main_measurements.cpp
@@ -27,8 +27,7 @@ void show_usage()
               << "\t-h,--help\t\tShow this help message\n"
               << "\t--timeout arg (=60)\tTest duration\n"
               << "\t--log arg (=out.csv)\tLog filename\n"
-              << "\t--process_name arg\tProcess_name\n"
-              << "\t--process_arguments arg\tProcess_arguments\n"
+              << "\t--process_pid arg\tProcess PID\n"
               << std::endl;
 }
 
@@ -36,27 +35,18 @@ int main(int argc, char * argv[])
 {
   float timeout = 60;
   std::ofstream m_os;
-  std::string pid_sub;
-  std::string process_name;
-  std::string process_arguments;
+  std::string process_pid;
 
   for (int i = 1; i < argc; ++i) {
     std::string arg = argv[i];
     if ((arg == "-h") || (arg == "--help")) {
         show_usage();
         return 0;
-    } else if (arg == "--process_name") {
+    } else if (arg == "--process_pid") {
         if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-            process_name = argv[++i]; // Increment 'i' so we don't get the argument as the next argv[i].
+            process_pid = argv[++i]; // Increment 'i' so we don't get the argument as the next argv[i].
         } else { // Uh-oh, there was no argument to the destination option.
-            std::cerr << "--process_name option requires one argument." << std::endl;
-            return 1;
-        }
-    } else if (arg == "--process_arguments") {
-        if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-            process_arguments = argv[++i]; // Increment 'i' so we don't get the argument as the next argv[i].
-        } else { // Uh-oh, there was no argument to the destination option.
-            std::cerr << "--process_arguments option requires one argument." << std::endl;
+            std::cerr << "--process_pid option requires one argument." << std::endl;
             return 1;
         }
     } else if (arg == "--timeout") {
@@ -85,28 +75,8 @@ int main(int argc, char * argv[])
 
   auto start = std::chrono::high_resolution_clock::now();
 
-  while (true) {
-    pid_sub = getPIDByName(process_name, argv[0], process_arguments);
-    std::cout << "pid_sub " << pid_sub << std::endl;
-
-    auto finish = std::chrono::high_resolution_clock::now();
-    std::chrono::duration<double, std::milli> elapsed = finish - start;
-    float seconds_running = elapsed.count() / 1000;
-
-    if (seconds_running > timeout) {
-      return -1;
-    }
-
-    if (pid_sub.empty() || atoi(pid_sub.c_str()) < 1024) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(50));
-      continue;
-    } else {
-      break;
-    }
-  }
-
-  LinuxMemoryProcessMeasurement linux_memory_process_measurement(pid_sub);
-  LinuxCPUProcessMeasurement linux_cpu_process_measurement(pid_sub);
+  LinuxMemoryProcessMeasurement linux_memory_process_measurement(process_pid);
+  LinuxCPUProcessMeasurement linux_cpu_process_measurement(process_pid);
 
   LinuxCPUSystemMeasurement linux_cpu_system_measurement;
   LinuxMemorySystemMeasurement linux_memory_system_measurement;

--- a/src/main_measurements.cpp
+++ b/src/main_measurements.cpp
@@ -44,14 +44,16 @@ int main(int argc, char * argv[])
       return 0;
     } else if (arg == "--process_pid") {
       if (i + 1 < argc) {   // Make sure we aren't at the end of argv!
-        process_pid = argv[++i];     // Increment 'i' so we don't get the argument as the next argv[i].
+        // Increment 'i' so we don't get the argument as the next argv[i].
+        process_pid = argv[++i];
       } else {   // Uh-oh, there was no argument to the destination option.
         std::cerr << "--process_pid option requires one argument." << std::endl;
         return 1;
       }
     } else if (arg == "--timeout") {
       if (i + 1 < argc) {   // Make sure we aren't at the end of argv!
-        timeout = std::atoi(argv[++i]);   // Increment 'i' so we don't get the argument as the next argv[i].
+        // Increment 'i' so we don't get the argument as the next argv[i].
+        timeout = std::atoi(argv[++i]);
       } else {   // Uh-oh, there was no argument to the destination option.
         std::cerr << "--timeout option requires one argument." << std::endl;
         return 1;

--- a/src/main_measurements.cpp
+++ b/src/main_measurements.cpp
@@ -1,0 +1,145 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <boost/program_options.hpp>
+#include <string>
+#include <chrono>
+#include <thread>
+#include "linux_memory_process_measurement.hpp"
+#include "linux_cpu_process_measurement.hpp"
+#include "linux_memory_system_measurement.hpp"
+#include "linux_cpu_system_measurement.hpp"
+
+int main(int argc, char * argv[])
+{
+  float timeout = 60;
+  std::ofstream m_os;
+  std::string pid_sub;
+  std::string process_name;
+  std::string process_arguments;
+
+  try {
+    boost::program_options::options_description desc{"Options"};
+
+    desc.add_options()("help,h", "Help screen")("timeout",
+      boost::program_options::value<float>()->default_value(30), "Test duration")("log",
+      boost::program_options::value<std::string>()->default_value("out.csv"),
+      "Log filename")("process_name",
+      boost::program_options::value<std::string>()->default_value(""),
+      "process_name")("process_arguments",
+      boost::program_options::value<std::string>()->default_value(""), "process_arguments");
+
+    boost::program_options::variables_map vm;
+    store(parse_command_line(argc, argv, desc), vm);
+    notify(vm);
+
+    if (vm.count("help")) {
+      std::cout << desc << '\n';
+      return 0;
+    }
+    if (vm.count("timeout")) {
+      timeout = vm["timeout"].as<float>();
+      printf("Duration of the test %5f\n", timeout);
+    }
+
+    if (vm.count("log")) {
+      m_os.open(vm["log"].as<std::string>(), std::ofstream::out);
+      std::cout << "file_name " << vm["log"].as<std::string>() << std::endl;
+      if (m_os.is_open()) {
+        m_os << "T_experiment" << ",cpu_usage (%)" << ",virtual memory (Mb)" <<
+          ",physical memory (Mb)" << ",resident anonymous memory (Mb)" <<
+          ",system_cpu_usage (%)" << ",system virtual memory (Mb)" << std::endl;
+      }
+    }
+
+    if (vm.count("process_name")) {
+      process_name = vm["process_name"].as<std::string>();
+      std::cout << "process_name " << process_name << std::endl;
+    }
+    if (vm.count("process_arguments")) {
+      process_arguments = vm["process_arguments"].as<std::string>();
+      std::cout << "process_arguments " << process_arguments << std::endl;
+    }
+  } catch (const boost::program_options::error & ex) {
+    std::cerr << ex.what() << '\n';
+  }
+
+  auto start = std::chrono::high_resolution_clock::now();
+
+  while (true) {
+    pid_sub = getPIDByName(process_name, argv[0], process_arguments);
+    std::cout << "pid_sub " << pid_sub << std::endl;
+
+    auto finish = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double, std::milli> elapsed = finish - start;
+    float seconds_running = elapsed.count() / 1000;
+
+    if (seconds_running > timeout) {
+      return -1;
+    }
+
+    if (pid_sub.empty() || atoi(pid_sub.c_str()) < 1024) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      continue;
+    } else {
+      break;
+    }
+  }
+
+  LinuxMemoryProcessMeasurement linux_memory_process_measurement(pid_sub);
+  LinuxCPUProcessMeasurement linux_cpu_process_measurement(pid_sub);
+
+  LinuxCPUSystemMeasurement linux_cpu_system_measurement;
+  LinuxMemorySystemMeasurement linux_memory_system_measurement;
+
+  while (true) {
+    linux_memory_process_measurement.makeReading();
+
+    double cpu_process_percentage =
+      linux_cpu_process_measurement.getCPUCurrentlyUsedByCurrentProcess();
+    double virtual_mem_process_usage = linux_memory_process_measurement.getVirtualMemUsedProcess();
+    double phy_mem_process_usage = linux_memory_process_measurement.getPhysMemUsedProcess();
+    double resident_anonymousMemory_process_usage =
+      linux_memory_process_measurement.getResidentAnonymousMemory();
+    double cpu_system_percentage = linux_cpu_system_measurement.getCPUSystemCurrentlyUsed();
+    double phy_mem_system_usage = linux_memory_system_measurement.getTotalMemorySystem() -
+      linux_memory_system_measurement.getAvailableMemorySystem();
+
+    std::cout << "virtualMemUsed Process: " << virtual_mem_process_usage << " Mb" << std::endl;
+    std::cout << "ResidentAnonymousMemory Process: " << resident_anonymousMemory_process_usage <<
+      " Mb" <<
+      std::endl;
+    std::cout << "PhysMemUsedProcess: " << phy_mem_process_usage << " Mb" << std::endl;
+    std::cout << "CPU Usage Process: " << cpu_process_percentage << " (%)" << std::endl;
+    std::cout << "CPU Usage system: " << cpu_system_percentage << " (%)" << std::endl;
+    std::cout << "PhysMemUsedsystem: " << phy_mem_system_usage << " (Mb)" << std::endl;
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    auto finish = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double, std::milli> elapsed = finish - start;
+    float seconds_running = elapsed.count() / 1000;
+    std::cout << "------------------------- " << std::endl;
+
+    if (seconds_running > timeout) {
+      break;
+    }
+
+    if (m_os.is_open()) {
+      m_os << seconds_running << ", " << cpu_process_percentage << ", " <<
+        virtual_mem_process_usage << ", " << phy_mem_process_usage << ", " <<
+        resident_anonymousMemory_process_usage << ", " << cpu_system_percentage <<
+        ", " << phy_mem_system_usage << std::endl;
+    }
+  }
+}

--- a/src/utilities/utilities.cpp
+++ b/src/utilities/utilities.cpp
@@ -29,37 +29,3 @@ std::vector<std::string> split(const std::string & s, char delimiter)
 
   return tokens;
 }
-
-std::string getPIDByName(std::string process_name, std::string my_own_name, std::string arguments)
-{
-  const std::string directory("/proc");
-
-  for (auto & process : fs::directory_iterator(directory)) {
-    std::string line;
-    std::ifstream myfile(std::string(process.path()) + std::string("/cmdline"));
-    if (myfile.is_open()) {
-      while (std::getline(myfile, line) ) {
-        if (line.find(process_name) != std::string::npos &&
-          !(line.find(my_own_name) != std::string::npos) &&
-          line.find(arguments) != std::string::npos)
-        {
-          std::cout << line << std::endl;
-
-          std::vector<std::string> tokens_cmdline = split(line, '\0');
-          std::vector<std::string> tokens_cmd = split(tokens_cmdline[0], '/');
-
-          std::string cmd = my_own_name;
-          if (tokens_cmd.size() > 0) {
-            std::cout << tokens_cmd[tokens_cmd.size() - 1] << std::endl;
-            if (!(tokens_cmd[tokens_cmd.size() - 1].find(process_name) != std::string::npos)) {
-              continue;
-            }
-          }
-          std::vector<std::string> tokens_pid = split(process.path(), '/');
-          return tokens_pid[1];
-        }
-      }
-    }
-  }
-  return std::string("");
-}

--- a/src/utilities/utilities.cpp
+++ b/src/utilities/utilities.cpp
@@ -1,0 +1,65 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "utilities/utilities.hpp"
+
+#include <string>
+#include <vector>
+
+std::vector<std::string> split(const std::string & s, char delimiter)
+{
+  std::vector<std::string> tokens;
+  std::string token;
+  std::istringstream tokenStream(s);
+  while (std::getline(tokenStream, token, delimiter)) {
+    if (!token.empty()) {
+      tokens.push_back(token);
+    }
+  }
+
+  return tokens;
+}
+
+std::string getPIDByName(std::string process_name, std::string my_own_name, std::string arguments)
+{
+  const std::string directory("/proc");
+
+  for (auto & process : fs::directory_iterator(directory)) {
+    std::string line;
+    std::ifstream myfile(std::string(process.path()) + std::string("/cmdline"));
+    if (myfile.is_open()) {
+      while (std::getline(myfile, line) ) {
+        if (line.find(process_name) != std::string::npos &&
+          !(line.find(my_own_name) != std::string::npos) &&
+          line.find(arguments) != std::string::npos)
+        {
+          std::cout << line << std::endl;
+
+          std::vector<std::string> tokens_cmdline = split(line, '\0');
+          std::vector<std::string> tokens_cmd = split(tokens_cmdline[0], '/');
+
+          std::string cmd = my_own_name;
+          if (tokens_cmd.size() > 0) {
+            std::cout << tokens_cmd[tokens_cmd.size() - 1] << std::endl;
+            if (!(tokens_cmd[tokens_cmd.size() - 1].find(process_name) != std::string::npos)) {
+              continue;
+            }
+          }
+          std::vector<std::string> tokens_pid = split(process.path(), '/');
+          return tokens_pid[1];
+        }
+      }
+    }
+  }
+  return std::string("");
+}


### PR DESCRIPTION
This tool allows to create statistics based on the name of the process and arguments:

 - CPU usage (%)
 - CPU memory virtual, ResidentAnonymousMemory and physical
 - Process usage (%)
 - Process memory: a) virtual, b) resident anonymous memory and c) physical

These are the argument to launch the tool:

```
ros2 run buildfarm_perf_tests system_metric_collector -h
Options:
  -h [ --help ]           Help screen
  --timeout arg (=30)     Test duration
  --log arg (=out.csv)    Log filename
  --process_name arg      process_name
  --process_arguments arg process_arguments
```

At some point potencially this tool shoul be replace by https://github.com/ros-tooling/system_metrics_collector/