### PR TITLE
Added script to generete config yaml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,4 +60,13 @@ install(TARGETS
   lib/${PROJECT_NAME}
 )
 
+install(DIRECTORY templates
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(PROGRAMS
+  scripts/generate_config_yaml.py
+  DESTINATION lib/${PROJECT_NAME}
+)
+
 ament_package()

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,8 @@
   <depend>rcpputils</depend>
   <depend>rcutils</depend>
 
+  <exec_depend>ament_index_python</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>launch</test_depend>

--- a/scripts/generate_config_yaml.py
+++ b/scripts/generate_config_yaml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/scripts/generate_config_yaml.py
+++ b/scripts/generate_config_yaml.py
@@ -1,0 +1,131 @@
+#!/usr/bin/python3
+
+import argparse
+import os
+import random
+from string import Template
+
+from ament_index_python import get_package_share_directory
+
+
+def add_line_to_plot_overhead(file_output, template_name, label, rmw_implementations, ci_name):
+    """Add line to plot overhead."""
+    with open(template_name, 'r') as content_file:
+        content = Template(content_file.read())
+
+    file_output.write('  ' + label + '\n')
+
+    for rmw_implementation in rmw_implementations:
+        random_number = rand_x_digit_num(19)
+        file_output.write(content.substitute(rmw_implementation=rmw_implementation,
+                                             ci_name=ci_name,
+                                             random_number=random_number))
+
+
+def rand_x_digit_num(x):
+    """Return an X digit number, leading_zeroes returns a string, otherwise int."""
+    return '{0:0{x}d}'.format(random.randint(0, 10**x-1), x=x)
+
+
+def fill_performance_test(file_output, template_name, label, ci_name):
+    """Add line to performance test."""
+    with open(template_name, 'r') as content_file:
+        content = Template(content_file.read())
+
+    file_output.write('  ' + label + '\n')
+
+    random_number = rand_x_digit_num(19)
+    file_output.write(content.substitute(ci_name=ci_name,
+                                         random_number=random_number))
+
+
+def performance_test(file_output, ci_name):
+    """Generate yaml file for performance tests."""
+    templates_path = os.path.join(get_package_share_directory('buildfarm_perf_tests'), 'templates')
+
+    fill_performance_test(file_output,
+                          os.path.join(templates_path, 'performance_test_1p_1k.txt'),
+                          'Performance One Process Test Results (Array1k)',
+                          ci_name)
+    fill_performance_test(file_output,
+                          os.path.join(templates_path, 'performance_test_1p_multi.txt'),
+                          'Performance One Process Test Results (multisize packets):',
+                          ci_name)
+    fill_performance_test(file_output,
+                          os.path.join(templates_path, 'performance_test_2p_1k.txt'),
+                          'Performance Two Processes Test Results (Array1k)',
+                          ci_name)
+    fill_performance_test(file_output,
+                          os.path.join(templates_path, 'performance_test_2p_multi.txt'),
+                          'Performance Two Processes Test Results (multisize packets):',
+                          ci_name)
+
+
+def node_spinnnig(file_output, ci_name):
+    """Generate yaml file for node spinning test."""
+    templates_path = os.path.join(get_package_share_directory('buildfarm_perf_tests'), 'templates')
+    with open(os.path.join(templates_path, 'node_spinning.txt'), 'r') as content_file:
+        content = Template(content_file.read())
+
+    file_output.write('  Node Spinnig Results:\n')
+
+    random_number = rand_x_digit_num(19)
+    file_output.write(content.substitute(ci_name=ci_name,
+                                         random_number=random_number))
+
+
+def overhead_simple_publisher_and_subscriber(file_output, rmw_implementations, ci_name):
+    """Generate yaml file for overhead simple publisher and subscriber tests."""
+    templates_path = os.path.join(get_package_share_directory('buildfarm_perf_tests'), 'templates')
+    add_line_to_plot_overhead(file_output,
+                              os.path.join(templates_path, 'overhead_round_trip.txt'),
+                              'Overhead simple publisher and subscriber - Average Round-Trip Time:',
+                              rmw_implementations, ci_name)
+    add_line_to_plot_overhead(
+                file_output,
+                os.path.join(templates_path, 'overhead_received_packets.txt'),
+                'Overhead simple publisher and subscriber - Received packets per second:',
+                rmw_implementations,
+                ci_name)
+    add_line_to_plot_overhead(file_output,
+                              os.path.join(templates_path, 'overhead_sent_packets.txt'),
+                              'Overhead simple publisher and subscriber - Sent packets per second:',
+                              rmw_implementations, ci_name)
+    add_line_to_plot_overhead(file_output,
+                              os.path.join(templates_path, 'overhead_lost_packets.txt'),
+                              'Overhead simple publisher and subscriber - Lost packets per second:',
+                              rmw_implementations, ci_name)
+    add_line_to_plot_overhead(file_output,
+                              os.path.join(templates_path, 'overhead_virtual_memory.txt'),
+                              'Overhead simple publisher and subscriber - Virtual Memory:',
+                              rmw_implementations, ci_name)
+    add_line_to_plot_overhead(
+                file_output,
+                os.path.join(templates_path, 'overhead_resident_anonymous_memory.txt'),
+                'Overhead simple publisher and subscriber - Resident Anonymous Memory:',
+                rmw_implementations,
+                ci_name)
+    add_line_to_plot_overhead(file_output,
+                              os.path.join(templates_path, 'overhead_physical_memory.txt'),
+                              'Overhead simple publisher and subscriber - Physical Memory:',
+                              rmw_implementations, ci_name)
+
+
+def main():
+    """Call main function."""
+    parser = argparse.ArgumentParser(description='Create ros buildfarm config.')
+    parser.add_argument('-filename', dest='filename', required=True,
+                        help='output file', metavar='FILE')
+    parser.add_argument('-ci_name', dest='ci_name', required=True,
+                        help='ci_name job', metavar='ci_name',)
+    parser.add_argument('-rmw_implementations', metavar='rmw_implementations', nargs='+',
+                        help='This will integrate the rmw_implementation in the plots')
+    args = parser.parse_args()
+
+    with open(args.filename, 'w') as f:
+        overhead_simple_publisher_and_subscriber(f, args.rmw_implementations, args.ci_name)
+        node_spinnnig(f, args.ci_name)
+        performance_test(f, args.ci_name)
+
+
+main()

--- a/scripts/generate_config_yaml.py
+++ b/scripts/generate_config_yaml.py
@@ -1,4 +1,16 @@
-#!/usr/bin/env python3
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import argparse
 import os
@@ -8,7 +20,7 @@ from string import Template
 from ament_index_python import get_package_share_directory
 
 
-def add_line_to_plot_overhead(file_output, template_name, label, rmw_implementations, ci_name):
+def add_line_plot_overhead(file_output, template_name, label, rmw_implementations, ci_name):
     """Add line to plot overhead."""
     with open(template_name, 'r') as content_file:
         content = Template(content_file.read())
@@ -77,38 +89,38 @@ def node_spinnnig(file_output, ci_name):
 def overhead_simple_publisher_and_subscriber(file_output, rmw_implementations, ci_name):
     """Generate yaml file for overhead simple publisher and subscriber tests."""
     templates_path = os.path.join(get_package_share_directory('buildfarm_perf_tests'), 'templates')
-    add_line_to_plot_overhead(file_output,
-                              os.path.join(templates_path, 'overhead_round_trip.txt'),
-                              'Overhead simple publisher and subscriber - Average Round-Trip Time:',
-                              rmw_implementations, ci_name)
-    add_line_to_plot_overhead(
+    add_line_plot_overhead(file_output,
+                           os.path.join(templates_path, 'overhead_round_trip.txt'),
+                           'Overhead simple publisher and subscriber - Average Round-Trip Time:',
+                           rmw_implementations, ci_name)
+    add_line_plot_overhead(
                 file_output,
                 os.path.join(templates_path, 'overhead_received_packets.txt'),
                 'Overhead simple publisher and subscriber - Received packets per second:',
                 rmw_implementations,
                 ci_name)
-    add_line_to_plot_overhead(file_output,
-                              os.path.join(templates_path, 'overhead_sent_packets.txt'),
-                              'Overhead simple publisher and subscriber - Sent packets per second:',
-                              rmw_implementations, ci_name)
-    add_line_to_plot_overhead(file_output,
-                              os.path.join(templates_path, 'overhead_lost_packets.txt'),
-                              'Overhead simple publisher and subscriber - Lost packets per second:',
-                              rmw_implementations, ci_name)
-    add_line_to_plot_overhead(file_output,
-                              os.path.join(templates_path, 'overhead_virtual_memory.txt'),
-                              'Overhead simple publisher and subscriber - Virtual Memory:',
-                              rmw_implementations, ci_name)
-    add_line_to_plot_overhead(
+    add_line_plot_overhead(file_output,
+                           os.path.join(templates_path, 'overhead_sent_packets.txt'),
+                           'Overhead simple publisher and subscriber - Sent packets per second:',
+                           rmw_implementations, ci_name)
+    add_line_plot_overhead(file_output,
+                           os.path.join(templates_path, 'overhead_lost_packets.txt'),
+                           'Overhead simple publisher and subscriber - Lost packets per second:',
+                           rmw_implementations, ci_name)
+    add_line_plot_overhead(file_output,
+                           os.path.join(templates_path, 'overhead_virtual_memory.txt'),
+                           'Overhead simple publisher and subscriber - Virtual Memory:',
+                           rmw_implementations, ci_name)
+    add_line_plot_overhead(
                 file_output,
                 os.path.join(templates_path, 'overhead_resident_anonymous_memory.txt'),
                 'Overhead simple publisher and subscriber - Resident Anonymous Memory:',
                 rmw_implementations,
                 ci_name)
-    add_line_to_plot_overhead(file_output,
-                              os.path.join(templates_path, 'overhead_physical_memory.txt'),
-                              'Overhead simple publisher and subscriber - Physical Memory:',
-                              rmw_implementations, ci_name)
+    add_line_plot_overhead(file_output,
+                           os.path.join(templates_path, 'overhead_physical_memory.txt'),
+                           'Overhead simple publisher and subscriber - Physical Memory:',
+                           rmw_implementations, ci_name)
 
 
 def main():

--- a/scripts/generate_config_yaml.py
+++ b/scripts/generate_config_yaml.py
@@ -114,11 +114,11 @@ def overhead_simple_publisher_and_subscriber(file_output, rmw_implementations, c
 def main():
     """Call main function."""
     parser = argparse.ArgumentParser(description='Create ros buildfarm config.')
-    parser.add_argument('-filename', dest='filename', required=True,
+    parser.add_argument('-f', '--filename', dest='filename', required=True,
                         help='output file', metavar='FILE')
-    parser.add_argument('-ci_name', dest='ci_name', required=True,
+    parser.add_argument('-c', '--ci_name', dest='ci_name', required=True,
                         help='ci_name job', metavar='ci_name',)
-    parser.add_argument('-rmw_implementations', metavar='rmw_implementations', nargs='+',
+    parser.add_argument('-rmw', '--rmw_implementations', metavar='rmw_implementations', nargs='+',
                         help='This will integrate the rmw_implementation in the plots')
     args = parser.parse_args()
 

--- a/templates/node_spinning.txt
+++ b/templates/node_spinning.txt
@@ -1,0 +1,60 @@
+  - title: Node Spinning Virtual Memory
+    description: "The figure shown above shows the virtual memory usage in Mb used by a single node spinning. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li></ul>"
+    y_axis_label: Mb
+    master_csv_name: plot-${random_number}.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    y_axis_minimum: 0
+    y_axis_maximum: 1024
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 2
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_node_test_results_%name%_virtual_memory.png
+  - title: Node Spinning CPU Usage
+    description: "The figure shown above shows the CPU usage in % used by a single node spinning. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li></ul>"
+    y_axis_label: Utilization (%)
+    master_csv_name: plot-${random_number}1.csv
+    style: line
+    num_builds: 10
+    y_axis_minimum: 0
+    y_axis_maximum: 100
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 5
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_node_test_results_%name%_cpu_usage.png
+  - title: Node Spinning Physical Memory
+    description: "The figure shown above shows the physical memory in Mb used by a single node spinning. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li></ul>"
+    y_axis_label: Mb
+    master_csv_name: plot-${random_number}2.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    y_axis_minimum: 0
+    y_axis_maximum: 100
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 8
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_node_test_results_%name%_physical_memory.png
+  - title: Node Spinning Resident Anonymous Memory
+    description: "The figure shown above shows the resident anonymous memory in Mb used by a single node spinning. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li></ul>"
+    y_axis_label: Mb
+    master_csv_name: plot-${random_number}3.csv
+    style: line
+    num_builds: 10
+    y_axis_minimum: 0
+    y_axis_maximum: 100
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 11
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_node_test_results_%name%_resident_anonymous_memory.png

--- a/templates/overhead_cpu_usage.txt
+++ b/templates/overhead_cpu_usage.txt
@@ -1,0 +1,30 @@
+  - title: Simple Pub ${rmw_implementation} CPU Usage
+    description: "The figure shown above shows the CPU usage in % used by the publisher. The publisher is set to <b>${rmw_implementation} </b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Utilization (%)
+    master_csv_name: plot-${random_number}.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    y_axis_minimum: 0
+    y_axis_maximum: 100
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/overhead_test_results_${rmw_implementation}_*_pub.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 5
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_test_results_%name%_publisher_cpu_usage.png
+  - title: Simple Sub ${rmw_implementation} CPU Usage
+    description: "The figure shown above shows the CPU usage in % used by the subscriber. The publisher is set to <b>${rmw_implementation} </b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Utilization (%)
+    master_csv_name: plot-${random_number}1.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    y_axis_minimum: 0
+    y_axis_maximum: 100
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/overhead_test_results_${rmw_implementation}_*_sub.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 5
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_test_results_%name%_subscriber_cpu_usage.png

--- a/templates/overhead_lost_packets.txt
+++ b/templates/overhead_lost_packets.txt
@@ -1,0 +1,14 @@
+  - title: Simple Pub ${rmw_implementation} Lost packets
+    description: "The figure shown above shows the lost packets. The publisher is set to <b>${rmw_implementation}</b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Total Count
+    master_csv_name: plot-$random_number.csv
+    style: line
+    num_builds: 10
+    y_axis_minimum: 0
+    y_axis_maximum: 10
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/overhead_test_results_${rmw_implementation}_*_pub.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 18
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_test_results_%name%_publisher_histogram.png

--- a/templates/overhead_physical_memory.txt
+++ b/templates/overhead_physical_memory.txt
@@ -1,0 +1,30 @@
+- title: Simple Pub ${rmw_implementation} Physical Memory
+  description: "The figure shown above shows the physical memory in Mb used by the publisher. The publisher is set to <b>${rmw_implementation} </b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
+  y_axis_label: Mb
+  master_csv_name: plot-${random_number}.csv
+  style: line
+  num_builds: 10
+  y_axis_exclude_zero: True
+  y_axis_minimum: 0
+  y_axis_maximum: 100
+  data_series:
+  - data_file: ws/test_results/buildfarm_perf_tests/overhead_test_results_${rmw_implementation}_*_pub.csv
+    data_type: csv
+    selection_flag: INCLUDE_BY_COLUMN
+    selection_value: 8
+    url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_test_results_%name%_publisher_physical_memory.png
+- title: Simple Sub ${rmw_implementation} Physical Memory
+  description: "The figure shown above shows the physical memory in Mb used by the subscriber. The publisher is set to <b>${rmw_implementation} </b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
+  y_axis_label: Mb
+  master_csv_name: plot-${random_number}1.csv
+  style: line
+  num_builds: 10
+  y_axis_exclude_zero: True
+  y_axis_minimum: 0
+  y_axis_maximum: 100
+  data_series:
+  - data_file: ws/test_results/buildfarm_perf_tests/overhead_test_results_${rmw_implementation}_*_sub.csv
+    data_type: csv
+    selection_flag: INCLUDE_BY_COLUMN
+    selection_value: 8
+    url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_test_results_%name%_subscriber_physical_memory.png

--- a/templates/overhead_received_packets.txt
+++ b/templates/overhead_received_packets.txt
@@ -1,0 +1,15 @@
+  - title: Simple Pub ${rmw_implementation} Received packets per second
+    description: "The figure shown above shows the received packets per second. The publisher is set to <b>${rmw_implementation}</b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Packets per second
+    master_csv_name: plot-$random_number.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    y_axis_minimum: 0
+    y_axis_maximum: 10
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/overhead_test_results_${rmw_implementation}_*_pub.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 16
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_test_results_%name%_publisher_histogram.png

--- a/templates/overhead_resident_anonymous_memory.txt
+++ b/templates/overhead_resident_anonymous_memory.txt
@@ -1,0 +1,26 @@
+  - title: Simple Pub ${rmw_implementation} Resident Anonymous Memory
+    description: "The figure shown above shows the resident anonymous memory in Mb used by the publisher. The publisher is set to <b>${rmw_implementation}</b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Mb
+    master_csv_name: plot-${random_number}.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/overhead_test_results_${rmw_implementation}_*_pub.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 11
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_test_results_%name%_publisher_resident_anonymous_memory.png
+  - title: Simple Sub ${rmw_implementation} Resident Anonymous Memory
+    description: "The figure shown above shows the resident anonymous memory in Mb used by the subscriber. The publisher is set to <b>${rmw_implementation}</b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Mb
+    master_csv_name: plot-${random_number}1.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/overhead_test_results_${rmw_implementation}_*_sub.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 11
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_test_results_%name%_subscriber_resident_anonymous_memory.png

--- a/templates/overhead_round_trip.txt
+++ b/templates/overhead_round_trip.txt
@@ -1,0 +1,13 @@
+  - title: Simple Pub ${rmw_implementation} Average Round-Trip Time
+    description: "The figure shown above shows the average round-trip time in milisecond. The publisher is set to <b>rmw_fastrtps_cpp </b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/overhead_test_results_${rmw_implementation}_*_pub.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 14
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_test_results_%name%_publisher_latency.png

--- a/templates/overhead_sent_packets.txt
+++ b/templates/overhead_sent_packets.txt
@@ -1,0 +1,15 @@
+  - title: Simple Pub ${rmw_implementation} Sent packets per second
+    description: "The figure shown above shows the sent packets per second. The publisher is set to <b>${rmw_implementation}</b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Packets per second
+    master_csv_name: plot-$random_number.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    y_axis_minimum: 0
+    y_axis_maximum: 10
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/overhead_test_results_${rmw_implementation}_*_pub.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 17
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_test_results_%name%_publisher_histogram.png

--- a/templates/overhead_virtual_memory.txt
+++ b/templates/overhead_virtual_memory.txt
@@ -1,0 +1,32 @@
+  - title: Simple Pub ${rmw_implementation} Virtual Memory
+    description: "The figure shown above shows the virtual memory in Mb used by the publisher. The publisher is set to <b>${rmw_implementation}</b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Mb
+    num_builds: 50
+    master_csv_name: plot-${random_number}.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    y_axis_minimum: 0
+    y_axis_maximum: 1000
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/overhead_test_results_${rmw_implementation}_*_pub.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 2
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_test_results_%name%_publisher_virtual_memory.png
+  - title: Simple Sub ${rmw_implementation} Virtual Memory
+      description: "The figure shown above shows the virtual memory in Mb used by the subscriber. The publisher is set to <b>${rmw_implementation}</b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
+      y_axis_label: Mb
+      num_builds: 50
+      master_csv_name: plot-${random_number}1.csv
+      style: line
+      num_builds: 10
+      y_axis_exclude_zero: True
+      y_axis_minimum: 0
+      y_axis_maximum: 1000
+      data_series:
+      - data_file: ws/test_results/buildfarm_perf_tests/overhead_test_results_${rmw_implementation}_*_sub.csv
+        data_type: csv
+        selection_flag: INCLUDE_BY_COLUMN
+        selection_value: 2
+        url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_test_results_%name%_subscriber_virtual_memory.png

--- a/templates/performance_test_1p_1k.txt
+++ b/templates/performance_test_1p_1k.txt
@@ -1,0 +1,97 @@
+  - title: Average Round-Trip Time
+    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}.csv
+    style: line
+    num_builds: 10
+    y_axis_minimum: 0
+    y_axis_maximum: 0.2
+    y_axis_exclude_zero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Throughtput
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Mbits/s (mean)
+    master_csv_name: plot-${random_number}1.csv
+    style: line
+    num_builds: 10
+    y_axis_minimum: 0
+    y_axis_maximum: 1000
+    y_axis_exclude_zero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughtput.png
+  - title: Max Resident Set Size
+    description: "The figure shown above shows the max resident size Megabytes for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Megabytes
+    master_csv_name: plot-${random_number}2.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 3
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Received packets
+    description: "The figure shown above shows the received packets for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}3.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 4
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_histogram.png
+  - title: Sent packets
+    description: "The figure shown above shows the sent packets for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}4.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 5
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_histogram.png
+  - title: Lost packets
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}5.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_histogram.png
+  - title: CPU usage (%)
+    description: "The figure shown above shows the cpu usage in % for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}6.csv
+    style: line
+    num_builds: 10
+    y_axis_minimum: 0
+    y_axis_maximum: 100
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 8
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_cpu_usage.png

--- a/templates/performance_test_1p_multi.txt
+++ b/templates/performance_test_1p_multi.txt
@@ -1,0 +1,208 @@
+  - title: Latency Average Round-Trip Time (Array1k)
+    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array4k)
+    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 4K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4K</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}1.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array4k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array16k)
+    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 16K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 16K</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}2.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array16k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array32k)
+    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 32K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 32K</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}3.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array32k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array60k)
+    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 60K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 60K</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}4.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array60k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Latency Average Round-Trip Time (PointCloud512k)
+    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 512K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 512K</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}5.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_PointCloud512k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array1m)
+    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 1M array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1M</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}6.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array2m)
+    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 2M array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 2M</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}7.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array2m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Throughput (Array1k)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}8.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (Array4k)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 4K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4K</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}9.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array4k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (Array16k)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 16K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 16K</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}10.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array16k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (Array32k)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 32K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 32K</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}11.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array32k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (Array60k)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 60K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 60K</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}12.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array60k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (PointCloud512k)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 512K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 512K</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}13.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_PointCloud512k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (Array1m)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 1M array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1M</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}14.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (Array2m)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 2M array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 2M</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}15.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array2m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png

--- a/templates/performance_test_2p_1k.txt
+++ b/templates/performance_test_2p_1k.txt
@@ -1,0 +1,97 @@
+  - title: Average Round-Trip Time
+    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}.csv
+    style: line
+    num_builds: 10
+    y_axis_minimum: 0
+    y_axis_maximum: 0.2
+    y_axis_exclude_zero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Throughtput
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1k</li></ul>"
+    y_axis_label: Mbits/s (mean)
+    master_csv_name: plot-${random_number}1.csv
+    style: line
+    num_builds: 10
+    y_axis_minimum: 0
+    y_axis_maximum: 1000
+    y_axis_exclude_zero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughtput.png
+  - title: Max Resident Set Size
+    description: "The figure shown above shows the max resident set size in Megabytes for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1k</li></ul>"
+    y_axis_label: Megabytes
+    master_csv_name: plot-${random_number}2.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 3
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Received packets
+    description: "The figure shown above shows the received packets per second for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1k</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}3.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 4
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_histogram.png
+  - title: Sent packets
+    description: "The figure shown above shows the sent packets per second for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1k</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}4.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 5
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_histogram.png
+  - title: Lost packets
+    description: "The figure shown above shows the total lost packets for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1k</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}5.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_histogram.png
+  - title: CPU usage (%)
+    description: "The figure shown above shows the CPU usage in % for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1k</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}6.csv
+    style: line
+    num_builds: 10
+    y_axis_minimum: 0
+    y_axis_maximum: 100
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 8
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_cpu_usage.png

--- a/templates/performance_test_2p_multi.txt
+++ b/templates/performance_test_2p_multi.txt
@@ -1,0 +1,208 @@
+  - title: Latency Average Round-Trip Time (Array1k)
+    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array4k)
+    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 4K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 4K</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}1.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array4k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array16k)
+    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 16K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 16K</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}2.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array16k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array32k)
+    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 32K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 32K</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}3.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array32k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array60k)
+    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 60K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 60K</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}4.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array60k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Latency Average Round-Trip Time (PointCloud512k)
+    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 512K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 512K</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}5.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_PointCloud512k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array1m)
+    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 1M array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1M</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}6.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array2m)
+    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 2M array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 2M</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}7.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array2m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Throughput (Array1k)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}8.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (Array4k)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 4K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4K</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}9.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array4k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (Array16k)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 16K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 16K</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}10.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array16k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (Array32k)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 32K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 32K</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}11.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array32k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (Array60k)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 60K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 60K</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}12.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array60k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (PointCloud512k)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 512K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 512K</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}13.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_PointCloud512k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (Array1m)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 1M array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1M</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}14.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (Array2m)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 2M array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 2M</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}15.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array2m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png


### PR DESCRIPTION
In order to include plots with the plot plugin in Jenkins. We need to create a [quite big yaml file](https://github.com/ros2/ros_buildfarm_config/blob/ros2/eloquent/ci-nightly-performance.yaml). The script is made to avoid generating this file by hand.

Signed-off-by: ahcorde <ahcorde@gmail.com>