### PR TITLE
Drop explicit rcpputils and rcutils dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,6 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(rcpputils REQUIRED)
-find_package(rcutils REQUIRED)
 
 add_executable(node_spinning src/node_spinning.cpp)
 ament_target_dependencies(node_spinning

--- a/package.xml
+++ b/package.xml
@@ -10,8 +10,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
-  <depend>rcpputils</depend>
-  <depend>rcutils</depend>
 
   <exec_depend>ament_index_python</exec_depend>
 


### PR DESCRIPTION
I don't see these packages referenced anywhere in this package.

@ahcorde, do you know why they were added?