### PR TITLE
[Dashing] Backported compile error and update dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,6 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(rcpputils REQUIRED)
-find_package(rcutils REQUIRED)
 
 add_executable(node_spinning src/node_spinning.cpp)
 ament_target_dependencies(node_spinning

--- a/package.xml
+++ b/package.xml
@@ -10,8 +10,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
-  <depend>rcpputils</depend>
-  <depend>rcutils</depend>
 
   <exec_depend>ament_index_python</exec_depend>
 

--- a/src/linux_cpu_process_measurement.cpp
+++ b/src/linux_cpu_process_measurement.cpp
@@ -16,9 +16,9 @@
 #include <vector>
 
 LinuxCPUProcessMeasurement::LinuxCPUProcessMeasurement(std::string pid)
-: pid_(pid),
-  tickspersec_(sysconf(_SC_CLK_TCK)),
-  numProcessors_(0)
+: numProcessors_(0),
+  pid_(pid),
+  tickspersec_(sysconf(_SC_CLK_TCK))
 {
   initCPUProcess();
 }


### PR DESCRIPTION

 - Fix compile warning with -Wreorder (#36)
 - Drop explicit rcpputils and rcutils dependencies (#35)
