### PR TITLE
Re-format CMakeLists.txt to reflect the ament_cmake template

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(buildfarm_perf_tests)
 
-if(WIN32 OR APPLE OR ANDROID)
-  message(STATUS "buildfarm_perf_tests is only supported on Linux, skipping...")
-  return()
-endif()
-
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
@@ -20,30 +15,40 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 
 add_executable(node_spinning src/node_spinning.cpp)
-ament_target_dependencies(node_spinning
-  rclcpp
+ament_target_dependencies(
+  node_spinning
+  "rclcpp"
 )
 
-include_directories(include)
+install(TARGETS node_spinning
+  EXPORT export_${PROJECT_NAME}
+  DESTINATION lib/${PROJECT_NAME})
 
-add_executable(system_metric_collector
-  src/main_measurements.cpp
-  src/linux_cpu_process_measurement.cpp
-  src/linux_memory_process_measurement.cpp
-  src/linux_cpu_system_measurement.cpp
-  src/linux_memory_system_measurement.cpp
-  src/utilities/utilities.cpp
-)
+option(ENABLE_SYSTEM_METRIC_COLLECTOR "Enables the system metric collector and tests which use it" ${UNIX})
+if(ENABLE_SYSTEM_METRIC_COLLECTOR)
+  add_executable(system_metric_collector
+    src/linux_cpu_process_measurement.cpp
+    src/linux_cpu_system_measurement.cpp
+    src/linux_memory_process_measurement.cpp
+    src/linux_memory_system_measurement.cpp
+    src/main_measurements.cpp
+    src/utilities/utilities.cpp
+  )
+  target_include_directories(system_metric_collector PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
+  target_link_libraries(system_metric_collector "stdc++fs")
 
-target_link_libraries(system_metric_collector
-  -lstdc++fs
-)
+  install(TARGETS system_metric_collector
+    EXPORT export_${PROJECT_NAME}
+    DESTINATION lib/${PROJECT_NAME})
+endif()
 
-install(TARGETS
-  system_metric_collector
-  DESTINATION
-  lib/${PROJECT_NAME}
-)
+install(DIRECTORY templates
+  DESTINATION share/${PROJECT_NAME})
+
+install(PROGRAMS scripts/generate_config_yaml.py
+  DESTINATION lib/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -51,20 +56,5 @@ if(BUILD_TESTING)
 
   add_subdirectory(test)
 endif()
-
-install(TARGETS
-  node_spinning
-  DESTINATION
-  lib/${PROJECT_NAME}
-)
-
-install(DIRECTORY templates
-  DESTINATION share/${PROJECT_NAME}
-)
-
-install(PROGRAMS
-  scripts/generate_config_yaml.py
-  DESTINATION lib/${PROJECT_NAME}
-)
 
 ament_package()


### PR DESCRIPTION
I'm trying to align the style with the official `ament_cmake` template and enable everything that we can on non-Unix systems. As far as I can tell, only the `system_metric_collector` is Unix-specific.