### PR TITLE
Don't run pub/sub or spinner tests on standalone DDS

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,8 @@ find_package(rmw_implementation_cmake REQUIRED)
 set(COMM_TYPE_rmw_cyclonedds_cpp "CycloneDDS")
 set(COMM_TYPE_rmw_fastrtps_cpp "FastRTPS")
 
+set(PERF_TEST_TOPIC_PUB_SUB Array60k
+  CACHE STRING "perf_test topic used by pub/stub tests")
 set(TOPICS
   Array1k
   Array4k
@@ -151,6 +153,10 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
     )
   endforeach()
 
+  if(NOT "${COMM}" STREQUAL "ROS2")
+    return()
+  endif()
+
   set(NODE_SPINNING_TIMEOUT "30")
   get_filename_component(
     PERFORMANCE_OVERHEAD_NODE_CSV
@@ -185,6 +191,7 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
     TIMEOUT 120
   )
   set(PUBSUB_TIMEOUT "30")
+  set(PERF_TEST_TOPIC ${PERF_TEST_TOPIC_PUB_SUB})
 
   get_available_rmw_implementations(_rmw_implementations)
 

--- a/test/test_pub_sub.py.in
+++ b/test/test_pub_sub.py.in
@@ -181,7 +181,7 @@ def generate_test_description(ready_fn):
     node_main_test = Node(
         package='performance_test', node_executable='perf_test', output='log',
         arguments=[
-            '-c', '@COMM@',
+            '-c', 'ROS2',
             '-t', '@PERF_TEST_TOPIC@',
             '--max_runtime', '@PUBSUB_TIMEOUT@',
             '-l', performance_log_prefix_pub,
@@ -195,7 +195,7 @@ def generate_test_description(ready_fn):
     node_relay_test = Node(
         package='performance_test', node_executable='perf_test', output='log',
         arguments=[
-            '-c', '@COMM@',
+            '-c', 'ROS2',
             '-t', '@PERF_TEST_TOPIC@',
             '--max_runtime', '@PUBSUB_TIMEOUT@',
             '-l', performance_log_prefix_sub,


### PR DESCRIPTION
The spinner is always a ROS 2 node, and doesn't have anything to do with the COMM value. Currently, the test is essentially a duplicate of its associated RMW test. We've been running these duplicate tests since the feature was added in #14.

For the pub/sub tests, if a standalone DDS is used for COMM, the relay is configured to the same COMM, and ignores the `RMW_IMPLEMENTATION` value that's being set. So the test looks like it has each RMW for a relay, but really its none of them, and is just the standalone DDS over and over. I really don't think we're interested in two-process performance of standalone DDS implementations, so let's just skip them instead of trying to fix the test to make sense. We've been running pub/sub tests on standalone DDS since the feature was added in #15.

Additionally, a static value is set for the topic used in the pub/sub tests instead of inheriting the last value iterated in the list of topics. This value was chosen to be large, but avoid fragmentation.