### PR TITLE
Fix pub/sub PNG file path

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -209,7 +209,7 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
     )
     get_filename_component(
       PERFORMANCE_OVERHEAD_PNG
-      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/overhead_test_results"
+      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/overhead_test_results_${TEST_NAME_PUB_SUB}.png"
       ABSOLUTE
     )
 


### PR DESCRIPTION
I'm pretty sure this is a bug. The code has been like this since the feature was introduced in #15.