### PR TITLE
Add PERF_TEST_SKIP flag to skip performance tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -79,6 +79,10 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
       set(SKIP_TEST "SKIP_TEST")
     endif()
 
+    if(PERF_TEST_SKIP)
+      set(SKIP_TEST "SKIP_TEST")
+    endif()
+
     set(NUMBER_PROCESS "1")
     get_filename_component(
       PERFORMANCE_REPORT_PNG
@@ -114,7 +118,7 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
     set(NUMBER_PROCESS "2")
     # TODO (ahcorde): perf_test is not working with CycloneDDS when
     # processes are splitted in two
-    if(${COMM} STREQUAL "CycloneDDS")
+    if(${COMM} STREQUAL "CycloneDDS" OR PERF_TEST_SKIP)
       set(SKIP_TEST "SKIP_TEST")
     endif()
 
@@ -152,6 +156,12 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
   endforeach()
 
   set(NODE_SPINNING_TIMEOUT "30")
+  set(SKIP_TEST "")
+  if(PERF_TEST_SKIP)
+    set(SKIP_TEST "SKIP_TEST")
+  endif()
+
+
   get_filename_component(
     PERFORMANCE_OVERHEAD_NODE_CSV
     "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/overhead_node_test_results_${TEST_NAME}.csv"
@@ -183,6 +193,7 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
     "RMW_FASTRTPS_USE_QOS_FROM_XML=${RMW_FASTRTPS_USE_QOS_FROM_XML}"
     "FASTRTPS_DEFAULT_PROFILES_FILE=${FASTRTPS_DEFAULT_PROFILES_FILE}"
     TIMEOUT 120
+    ${SKIP_TEST}
   )
   set(PUBSUB_TIMEOUT "30")
 
@@ -194,7 +205,7 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
     #  processes are splitted in two
     # what(): Round tip mode is not implemented for Cyclone DDS
     set(SKIP_TEST "")
-    if(${COMM} STREQUAL "CycloneDDS")
+    if(${COMM} STREQUAL "CycloneDDS" OR PERF_TEST_SKIP)
       set(SKIP_TEST "SKIP_TEST")
     endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(PERF_TEST_SKIP OFF
+  CACHE BOOL "Skip all of the performance tests and only test the package itself")
 set(PERF_TEST_MAX_RUNTIME 30
   CACHE STRING "Duration for each performance test run")
 


### PR DESCRIPTION
This boolean flag will cause the test run for `buildfarm_perf_tests` to skip all of the actual performance tests and only run the tests on the package itself, such as the linters.

The idea is to use this flag to enable some continuous integration for the package so that we can keep the linters from regressing.