### PR TITLE
Add continuous integration via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,35 @@
+name: Continuous Integration
+on: [push, pull_request]
+
+jobs:
+  build_and_test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    container: ${{matrix.container_image}}
+    strategy:
+      matrix:
+        container_image: ['ros:eloquent', 'osrf/ros2:nightly-rmw-nonfree']
+
+    steps:
+    - name: Clone buildfarm_perf_tests
+      uses: actions/checkout@v2
+      with:
+        path: src/buildfarm_perf_tests
+    - name: Update, build, and test
+      run: |
+        echo ::group::Update packages
+        apt-get update
+        apt-get upgrade -y
+        rosdep update
+        echo ::endgroup::
+        . /opt/ros/*/setup.sh
+        echo ::group::Install dependencies
+        rosdep install -y --from-path src --ignore-src --skip-keys 'performance_test'
+        echo ::endgroup::
+        echo ::group::Build package
+        colcon build --event-handler console_direct+ --cmake-args -DPERF_TEST_SKIP:BOOL=1 -DCMAKE_CXX_FLAGS=-Werror -Werror=dev -Werror=deprecated
+        echo ::endgroup::
+        echo ::group::Test package
+        colcon test --event-handler console_direct+
+        echo ::endgroup::
+        colcon test-result

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # buildfarm perf tests
 
+![buildfarm_perf_tests CI](https://github.com/ros2/buildfarm_perf_tests/workflows/Continuous%20Integration/badge.svg?branch=master&event=push)
+
 ## Purpose
 
 This package defines some tests. On one hand it invokes `perf_test` from Apex.AI's [performance_test](https://gitlab.com/ApexAI/performance_test) package. This allows you to test performance and latency of several ROS 2 RMW implementations. On the other hand we are evaluating the additional overhead caused by a single pub/sub topic or one process spinning and detect potential leaks related to theses activities.


### PR DESCRIPTION
Since we're targeting the `master` branch for both Foxy and Eloquent, we'll run test for both.

For the `dashing` branch, I'll adjust the container so that we only test with Dashing there.

Note that I added some options to treat warnings as errors, so it should block PRs that regress CMake and compiler warnings.