### PR TITLE
Run flake8 on launch tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
         . /opt/ros/*/setup.sh
         echo ::group::Install dependencies
         rosdep install -y --from-path src --ignore-src --skip-keys 'performance_test'
-        pip3 install flake8_quotes
+        pip3 install flake8_builtins flake8_quotes
         echo ::endgroup::
         echo ::group::Build package
         colcon build --event-handler console_direct+ --cmake-args -DCMAKE_CXX_FLAGS=-Werror -Werror=dev -Werror=deprecated

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
         . /opt/ros/*/setup.sh
         echo ::group::Install dependencies
         rosdep install -y --from-path src --ignore-src --skip-keys 'performance_test'
+        pip3 install flake8_quotes
         echo ::endgroup::
         echo ::group::Build package
         colcon build --event-handler console_direct+ --cmake-args -DCMAKE_CXX_FLAGS=-Werror -Werror=dev -Werror=deprecated

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(PERF_TEST_MAX_RUNTIME 30
   CACHE STRING "Duration for each performance test run")
 
+find_package(ament_cmake_flake8 REQUIRED)
 find_package(launch_testing_ament_cmake REQUIRED)
 find_package(rmw_implementation_cmake REQUIRED)
 
@@ -18,6 +19,10 @@ set(TOPICS
   PointCloud512k
   Array1m
   Array2m
+)
+
+ament_flake8(TESTNAME "flake8_generated"
+  ${CMAKE_CURRENT_BINARY_DIR}/test
 )
 
 function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)

--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -54,7 +54,7 @@ def _raw_to_csv(dataframe, csv_path):
         dataframe_agg.loc['mean', 'cpu_usage (%)'],
         dataframe['cpu_usage (%)'].describe(percentiles=[0.95]).iloc[5],
         dataframe_agg.loc['median', 'cpu_usage (%)'],
-        dataframe_agg.loc['mean', 'data_received'] *BYTE_TO_MBYTE,
+        dataframe_agg.loc['mean', 'data_received'] * BYTE_TO_MBYTE,
         dataframe_agg.loc['median', 'data_received'] * BYTE_TO_MBYTE,
         dataframe['data_received'].describe(percentiles=[0.95]).iloc[5] * BYTE_TO_MBYTE,
     ]
@@ -73,37 +73,44 @@ def _raw_to_png(dataframe, png_path):
     percentils_latency = dataframe['latency_mean (ms)'].describe(percentiles=[0.95])
     dataframe['latency_p95 (ms)'] = percentils_latency.iloc[5]
     ax = dataframe[['T_experiment',
-               'latency_min (ms)',
-               'latency_max (ms)',
-               'latency_mean (ms)',
-               'latency_p95 (ms)',
-               'latency_variance (ms) * 100',
-               'maxrss (Mb)']].plot(x='T_experiment', secondary_y=['maxrss (Mb)'])
+                    'latency_min (ms)',
+                    'latency_max (ms)',
+                    'latency_mean (ms)',
+                    'latency_p95 (ms)',
+                    'latency_variance (ms) * 100',
+                    'maxrss (Mb)']].plot(x='T_experiment', secondary_y=['maxrss (Mb)'])
 
     plot_name = "One Process"
 
     if '@NUMBER_PROCESS@' == 2:
-      plot_name = "Two Processes"
+        plot_name = "Two Processes"
 
-    plt.title('Performance ' + plot_name + ' tests latency\n@TEST_NAME@ @PERF_TEST_TOPIC@')
+    plt.title('Performance ' + plot_name +
+              ' tests latency\n@TEST_NAME@ @PERF_TEST_TOPIC@')
     ax.set_ylabel("ms")
     plt.savefig(png_path)
 
     dataframe['data_received Mbits/s'] = dataframe['data_received'] * BYTE_TO_MBYTE
     percentils_data_received = dataframe['data_received Mbits/s'].describe(percentiles=[0.95])
     dataframe['data_received Mbits/s (P95)'] = percentils_data_received.iloc[5]
-    ax = dataframe[['T_experiment',  'data_received Mbits/s', 'data_received Mbits/s (P95)']].plot(x='T_experiment')
-    plt.title('Performance ' + plot_name + ' Throughput (Mbits/s) Tests\n@TEST_NAME@ @PERF_TEST_TOPIC@')
+    ax = dataframe[['T_experiment',
+                    'data_received Mbits/s',
+                    'data_received Mbits/s (P95)']].plot(x='T_experiment')
+    plt.title('Performance ' + plot_name
+              + ' Throughput (Mbits/s) Tests\n@TEST_NAME@ @PERF_TEST_TOPIC@')
     ax.set_ylabel("Mbits/s")
     plt.savefig(png_path[:-4] + "_throughput.png")
 
     ax = dataframe[['T_experiment', 'cpu_usage (%)']].plot(x='T_experiment')
-    plt.title('Performance ' + plot_name + ' tests CPU usage (%)\n@TEST_NAME@ @PERF_TEST_TOPIC@')
+    plt.title('Performance ' + plot_name
+              + ' tests CPU usage (%)\n@TEST_NAME@ @PERF_TEST_TOPIC@')
     ax.set_ylabel("%")
     plt.savefig(png_path[:-4] + "_cpu_usage.png")
 
     ax = dataframe.plot(kind='bar', y=['received', 'sent', 'lost'])
-    plt.title(plot_name + ' Received/Sent packets per second and Lost packets\n@TEST_NAME@ @PERF_TEST_TOPIC@')
+    plt.title(plot_name
+              + ' Received/Sent packets per second and Lost packets\n'
+              + '@TEST_NAME@ @PERF_TEST_TOPIC@')
     ax.set_ylabel("Number of packets")
     plt.savefig(png_path[:-4] + "_histogram.png")
 
@@ -123,7 +130,7 @@ def generate_test_description(ready_fn):
 
     sync_env = {}
     if '@SYNC_MODE@' == 'sync' and '@COMM@' != 'ROS2':
-      args.append('--disable_async')
+        args.append('--disable_async')
 
     nodes = []
 
@@ -168,7 +175,8 @@ class PerformanceTestTermination(unittest.TestCase):
 @launch_testing.post_shutdown_test()
 class PerformanceTestResults(unittest.TestCase):
 
-    def test_results_@TEST_NAME@(self, performance_log_prefix, nodes, proc_info):
+    def test_results_@TEST_NAME@(
+            self, performance_log_prefix, nodes, proc_info):
         self.addCleanup(_cleanUpLogs, performance_log_prefix)
 
         for node in nodes:

--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -80,14 +80,14 @@ def _raw_to_png(dataframe, png_path):
                     'latency_variance (ms) * 100',
                     'maxrss (Mb)']].plot(x='T_experiment', secondary_y=['maxrss (Mb)'])
 
-    plot_name = "One Process"
+    plot_name = 'One Process'
 
     if '@NUMBER_PROCESS@' == 2:
-        plot_name = "Two Processes"
+        plot_name = 'Two Processes'
 
     plt.title('Performance ' + plot_name +
               ' tests latency\n@TEST_NAME@ @PERF_TEST_TOPIC@')
-    ax.set_ylabel("ms")
+    ax.set_ylabel('ms')
     plt.savefig(png_path)
 
     dataframe['data_received Mbits/s'] = dataframe['data_received'] * BYTE_TO_MBYTE
@@ -98,21 +98,21 @@ def _raw_to_png(dataframe, png_path):
                     'data_received Mbits/s (P95)']].plot(x='T_experiment')
     plt.title('Performance ' + plot_name
               + ' Throughput (Mbits/s) Tests\n@TEST_NAME@ @PERF_TEST_TOPIC@')
-    ax.set_ylabel("Mbits/s")
-    plt.savefig(png_path[:-4] + "_throughput.png")
+    ax.set_ylabel('Mbits/s')
+    plt.savefig(png_path[:-4] + '_throughput.png')
 
     ax = dataframe[['T_experiment', 'cpu_usage (%)']].plot(x='T_experiment')
     plt.title('Performance ' + plot_name
               + ' tests CPU usage (%)\n@TEST_NAME@ @PERF_TEST_TOPIC@')
-    ax.set_ylabel("%")
-    plt.savefig(png_path[:-4] + "_cpu_usage.png")
+    ax.set_ylabel('%')
+    plt.savefig(png_path[:-4] + '_cpu_usage.png')
 
     ax = dataframe.plot(kind='bar', y=['received', 'sent', 'lost'])
     plt.title(plot_name
               + ' Received/Sent packets per second and Lost packets\n'
               + '@TEST_NAME@ @PERF_TEST_TOPIC@')
-    ax.set_ylabel("Number of packets")
-    plt.savefig(png_path[:-4] + "_histogram.png")
+    ax.set_ylabel('Number of packets')
+    plt.savefig(png_path[:-4] + '_histogram.png')
 
 
 def generate_test_description(ready_fn):
@@ -124,7 +124,7 @@ def generate_test_description(ready_fn):
         '-c', '@COMM@',
         '-t', '@PERF_TEST_TOPIC@',
         '--max_runtime', '@PERF_TEST_MAX_RUNTIME@',
-        "--ignore", "3",
+        '--ignore', '3',
         '-l', performance_log_prefix,
     ]
 
@@ -144,7 +144,7 @@ def generate_test_description(ready_fn):
               '-c', '@COMM@',
               '-t', '@PERF_TEST_TOPIC@',
               '--max_runtime', '@PERF_TEST_MAX_RUNTIME@',
-              "--roundtrip_mode", "Relay",
+              '--roundtrip_mode', 'Relay',
           ],
         )
         launch_description.append(node_relay)

--- a/test/test_pub_sub.py.in
+++ b/test/test_pub_sub.py.in
@@ -76,25 +76,29 @@ def _raw_to_png(dataframe, dataframe_perf, png_path, type, rmw_impl):
     dataframe[['T_experiment', 'virtual memory (Mb)']].plot(x='T_experiment')
     plt.title('Simple Pub/Sub virtual memory usage\n' + type + ': ' + rmw_impl)
     plt.ylim(0, 1024)
-    plt.savefig(png_path + "_" + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
+    plt.savefig(png_path + "_"
+                + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
                 + type + "_virtual_memory.png")
 
     dataframe[['T_experiment', 'cpu_usage (%)']].plot(x='T_experiment')
     plt.title('Simple Pub/Sub CPU usage\n' + type + ': ' + rmw_impl)
     plt.ylim(0, 100)
-    plt.savefig(png_path + "_" + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
+    plt.savefig(png_path + "_"
+                + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
                 + type + "_cpu_usage.png")
 
     dataframe[['T_experiment', 'physical memory (Mb)']].plot(x='T_experiment')
     plt.title('Simple Pub/Sub physical memory usage\n' + type + ': ' + rmw_impl)
     plt.ylim(0, 100)
-    plt.savefig(png_path + "_" + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
+    plt.savefig(png_path + "_"
+                + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
                 + type + "_physical_memory.png")
 
     dataframe[['T_experiment', 'resident anonymous memory (Mb)']].plot(x='T_experiment')
     plt.title('Simple Pub/Sub resident anonymous memory\n' + type + ': ' + rmw_impl)
     plt.ylim(0, 100)
-    plt.savefig(png_path + "_" + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
+    plt.savefig(png_path + "_"
+                + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
                 + type + "_resident_anonymous_memory.png")
 
     if type == 'subscriber':
@@ -104,7 +108,8 @@ def _raw_to_png(dataframe, dataframe_perf, png_path, type, rmw_impl):
     pd.options.display.float_format = '{:.4f}'.format
     dataframe.plot(kind='bar', y=['received', 'sent', 'lost'])
     plt.title('Simple Pub/Sub Received/Sent/Lost packets\n' + type + ': ' + rmw_impl)
-    plt.savefig(png_path + "_" + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
+    plt.savefig(png_path + "_"
+                + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
                 + type + "_histogram.png")
 
     dataframe['maxrss (Mb)'] = dataframe['ru_maxrss'] / 1e3
@@ -118,19 +123,28 @@ def _raw_to_png(dataframe, dataframe_perf, png_path, type, rmw_impl):
                'maxrss (Mb)']].plot(x='T_experiment', secondary_y=['maxrss (Mb)'])
     plt.title('Simple Pub/Sub latency\n' + type + ': ' + "@COMM_PUB@"
               + "\nsubscriber: " + "@COMM_SUB@")
-    plt.savefig(png_path + "_" + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
+    plt.savefig(png_path + "_"
+                + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
                 + type + "_latency.png")
 
 
 def generate_test_description(ready_fn):
     performance_log_prefix_cpumem_pub = tempfile.mkstemp(
-        prefix='overhead_cpumem_pub_test_results_@TEST_NAME_PUB_SUB@_', text=True)[1]
+        prefix='overhead_cpumem_pub_test_results_'
+               + '@TEST_NAME_PUB_SUB@_',
+        text=True)[1]
     performance_log_prefix_cpumem_sub = tempfile.mkstemp(
-        prefix='overhead_cpumem_sub_test_results_@TEST_NAME_PUB_SUB@_', text=True)[1]
+        prefix='overhead_cpumem_sub_test_results_'
+               + '@TEST_NAME_PUB_SUB@_',
+        text=True)[1]
     performance_log_prefix_pub = tempfile.mkstemp(
-        prefix='overhead_pub_test_results_@TEST_NAME_PUB_SUB@_', text=True)[1]
+        prefix='overhead_pub_test_results_'
+               + '@TEST_NAME_PUB_SUB@_',
+        text=True)[1]
     performance_log_prefix_sub = tempfile.mkstemp(
-        prefix='overhead_sub_test_results_@TEST_NAME_PUB_SUB@_', text=True)[1]
+        prefix='overhead_sub_test_results_'
+               + '@TEST_NAME_PUB_SUB@_',
+        text=True)[1]
 
     node_main_test = Node(
         package='performance_test', node_executable='perf_test', output='log',
@@ -178,9 +192,9 @@ def generate_test_description(ready_fn):
 
 class PerformanceTestTermination(unittest.TestCase):
 
-    def test_termination_@TEST_NAME_PUB_SUB@(self, system_metric_collector_sub,
-                                             system_metric_collector_pub, node_main_test,
-                                             node_relay_test, proc_info):
+    def test_termination_@TEST_NAME_PUB_SUB@(
+            self, system_metric_collector_sub, system_metric_collector_pub,
+            node_main_test, node_relay_test, proc_info):
         proc_info.assertWaitForShutdown(process=system_metric_collector_sub,
                                         timeout=(@PUBSUB_TIMEOUT@ * 2))
         proc_info.assertWaitForShutdown(process=system_metric_collector_pub,
@@ -192,14 +206,11 @@ class PerformanceTestTermination(unittest.TestCase):
 @launch_testing.post_shutdown_test()
 class PerformanceTestResults(unittest.TestCase):
 
-    def test_results_@TEST_NAME_PUB_SUB@(self,
-                                         performance_log_prefix_cpumem_pub,
-                                         performance_log_prefix_cpumem_sub,
-                                         performance_log_prefix_pub,
-                                         performance_log_prefix_sub,
-                                         proc_info,
-                                         node_relay_test,
-                                         node_main_test):
+    def test_results_@TEST_NAME_PUB_SUB@(
+            self,
+            performance_log_prefix_cpumem_pub, performance_log_prefix_cpumem_sub,
+            performance_log_prefix_pub, performance_log_prefix_sub,
+            proc_info, node_relay_test, node_main_test):
         self.addCleanup(_cleanUpLogs, performance_log_prefix_pub)
         self.addCleanup(_cleanUpLogs, performance_log_prefix_sub)
         self.addCleanup(_cleanUpLogs, performance_log_prefix_cpumem_pub)
@@ -221,7 +232,8 @@ class PerformanceTestResults(unittest.TestCase):
         performance_logs_perf_test = glob(performance_log_prefix_pub + '_*')
 
         if performance_logs and performance_logs_perf_test:
-            performance_log_data = read_performance_test_csv(performance_logs[0], start_marker=None)
+            performance_log_data = read_performance_test_csv(
+                performance_logs[0], start_marker=None)
             performance_log_perf_data = read_performance_test_csv(performance_logs_perf_test[0])
 
             performance_report_csv = os.environ.get('PERFORMANCE_OVERHEAD_CSV')
@@ -246,7 +258,8 @@ class PerformanceTestResults(unittest.TestCase):
         performance_logs_perf_test = glob(performance_log_prefix_sub + '_*')
 
         if performance_logs and performance_logs_perf_test:
-            performance_log_data = read_performance_test_csv(performance_logs[0], start_marker=None)
+            performance_log_data = read_performance_test_csv(
+                performance_logs[0], start_marker=None)
             performance_log_perf_data = read_performance_test_csv(performance_logs_perf_test[0])
 
             performance_report_csv = os.environ.get('PERFORMANCE_OVERHEAD_CSV')

--- a/test/test_pub_sub.py.in
+++ b/test/test_pub_sub.py.in
@@ -27,7 +27,7 @@ def _cleanUpLogs(performance_log_prefix):
         os.remove(log)
 
 
-def _raw_to_csv(dataframe, dataframe_perf, csv_path, type):
+def _raw_to_csv(dataframe, dataframe_perf, csv_path, mode):
     """
     Convert from the raw csv data to the csv for the Jenkins plot plugin.
 
@@ -66,51 +66,51 @@ def _raw_to_csv(dataframe, dataframe_perf, csv_path, type):
     ]
 
     write_jenkins_plot_csv(
-        '%s_%s.csv' % (csv_path[:-4], type),
+        '%s_%s.csv' % (csv_path[:-4], mode),
         'Publisher-@TEST_NAME@_Subscriber-@COMM_SUB@', values)
 
 
-def _raw_to_png(dataframe, dataframe_perf, png_path, type, rmw_impl):
+def _raw_to_png(dataframe, dataframe_perf, png_path, mode, rmw_impl):
     pd.options.display.float_format = '{:.4f}'.format
 
     dataframe[['T_experiment', 'virtual memory (Mb)']].plot(x='T_experiment')
-    plt.title('Simple Pub/Sub virtual memory usage\n' + type + ': ' + rmw_impl)
+    plt.title('Simple Pub/Sub virtual memory usage\n' + mode + ': ' + rmw_impl)
     plt.ylim(0, 1024)
     plt.savefig(png_path + '_'
                 + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
-                + type + '_virtual_memory.png')
+                + mode + '_virtual_memory.png')
 
     dataframe[['T_experiment', 'cpu_usage (%)']].plot(x='T_experiment')
-    plt.title('Simple Pub/Sub CPU usage\n' + type + ': ' + rmw_impl)
+    plt.title('Simple Pub/Sub CPU usage\n' + mode + ': ' + rmw_impl)
     plt.ylim(0, 100)
     plt.savefig(png_path + '_'
                 + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
-                + type + '_cpu_usage.png')
+                + mode + '_cpu_usage.png')
 
     dataframe[['T_experiment', 'physical memory (Mb)']].plot(x='T_experiment')
-    plt.title('Simple Pub/Sub physical memory usage\n' + type + ': ' + rmw_impl)
+    plt.title('Simple Pub/Sub physical memory usage\n' + mode + ': ' + rmw_impl)
     plt.ylim(0, 100)
     plt.savefig(png_path + '_'
                 + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
-                + type + '_physical_memory.png')
+                + mode + '_physical_memory.png')
 
     dataframe[['T_experiment', 'resident anonymous memory (Mb)']].plot(x='T_experiment')
-    plt.title('Simple Pub/Sub resident anonymous memory\n' + type + ': ' + rmw_impl)
+    plt.title('Simple Pub/Sub resident anonymous memory\n' + mode + ': ' + rmw_impl)
     plt.ylim(0, 100)
     plt.savefig(png_path + '_'
                 + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
-                + type + '_resident_anonymous_memory.png')
+                + mode + '_resident_anonymous_memory.png')
 
-    if type == 'subscriber':
+    if mode == 'subscriber':
         return
 
     dataframe = dataframe_perf.copy()
     pd.options.display.float_format = '{:.4f}'.format
     dataframe.plot(kind='bar', y=['received', 'sent', 'lost'])
-    plt.title('Simple Pub/Sub Received/Sent/Lost packets\n' + type + ': ' + rmw_impl)
+    plt.title('Simple Pub/Sub Received/Sent/Lost packets\n' + mode + ': ' + rmw_impl)
     plt.savefig(png_path + '_'
                 + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
-                + type + '_histogram.png')
+                + mode + '_histogram.png')
 
     dataframe['maxrss (Mb)'] = dataframe['ru_maxrss'] / 1e3
     dataframe.drop(list(dataframe.filter(regex='ru_')), axis=1, inplace=True)
@@ -121,11 +121,11 @@ def _raw_to_png(dataframe, dataframe_perf, png_path, type, rmw_impl):
                'latency_mean (ms)',
                'latency_variance (ms) * 100',
                'maxrss (Mb)']].plot(x='T_experiment', secondary_y=['maxrss (Mb)'])
-    plt.title('Simple Pub/Sub latency\n' + type + ': ' + '@COMM_PUB@'
+    plt.title('Simple Pub/Sub latency\n' + mode + ': ' + '@COMM_PUB@'
               + '\nsubscriber: ' + '@COMM_SUB@')
     plt.savefig(png_path + '_'
                 + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
-                + type + '_latency.png')
+                + mode + '_latency.png')
 
 
 def generate_test_description(ready_fn):

--- a/test/test_pub_sub.py.in
+++ b/test/test_pub_sub.py.in
@@ -76,30 +76,30 @@ def _raw_to_png(dataframe, dataframe_perf, png_path, type, rmw_impl):
     dataframe[['T_experiment', 'virtual memory (Mb)']].plot(x='T_experiment')
     plt.title('Simple Pub/Sub virtual memory usage\n' + type + ': ' + rmw_impl)
     plt.ylim(0, 1024)
-    plt.savefig(png_path + "_"
+    plt.savefig(png_path + '_'
                 + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
-                + type + "_virtual_memory.png")
+                + type + '_virtual_memory.png')
 
     dataframe[['T_experiment', 'cpu_usage (%)']].plot(x='T_experiment')
     plt.title('Simple Pub/Sub CPU usage\n' + type + ': ' + rmw_impl)
     plt.ylim(0, 100)
-    plt.savefig(png_path + "_"
+    plt.savefig(png_path + '_'
                 + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
-                + type + "_cpu_usage.png")
+                + type + '_cpu_usage.png')
 
     dataframe[['T_experiment', 'physical memory (Mb)']].plot(x='T_experiment')
     plt.title('Simple Pub/Sub physical memory usage\n' + type + ': ' + rmw_impl)
     plt.ylim(0, 100)
-    plt.savefig(png_path + "_"
+    plt.savefig(png_path + '_'
                 + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
-                + type + "_physical_memory.png")
+                + type + '_physical_memory.png')
 
     dataframe[['T_experiment', 'resident anonymous memory (Mb)']].plot(x='T_experiment')
     plt.title('Simple Pub/Sub resident anonymous memory\n' + type + ': ' + rmw_impl)
     plt.ylim(0, 100)
-    plt.savefig(png_path + "_"
+    plt.savefig(png_path + '_'
                 + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
-                + type + "_resident_anonymous_memory.png")
+                + type + '_resident_anonymous_memory.png')
 
     if type == 'subscriber':
         return
@@ -108,9 +108,9 @@ def _raw_to_png(dataframe, dataframe_perf, png_path, type, rmw_impl):
     pd.options.display.float_format = '{:.4f}'.format
     dataframe.plot(kind='bar', y=['received', 'sent', 'lost'])
     plt.title('Simple Pub/Sub Received/Sent/Lost packets\n' + type + ': ' + rmw_impl)
-    plt.savefig(png_path + "_"
+    plt.savefig(png_path + '_'
                 + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
-                + type + "_histogram.png")
+                + type + '_histogram.png')
 
     dataframe['maxrss (Mb)'] = dataframe['ru_maxrss'] / 1e3
     dataframe.drop(list(dataframe.filter(regex='ru_')), axis=1, inplace=True)
@@ -121,11 +121,11 @@ def _raw_to_png(dataframe, dataframe_perf, png_path, type, rmw_impl):
                'latency_mean (ms)',
                'latency_variance (ms) * 100',
                'maxrss (Mb)']].plot(x='T_experiment', secondary_y=['maxrss (Mb)'])
-    plt.title('Simple Pub/Sub latency\n' + type + ': ' + "@COMM_PUB@"
-              + "\nsubscriber: " + "@COMM_SUB@")
-    plt.savefig(png_path + "_"
+    plt.title('Simple Pub/Sub latency\n' + type + ': ' + '@COMM_PUB@'
+              + '\nsubscriber: ' + '@COMM_SUB@')
+    plt.savefig(png_path + '_'
                 + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
-                + type + "_latency.png")
+                + type + '_latency.png')
 
 
 def generate_test_description(ready_fn):
@@ -155,7 +155,7 @@ def generate_test_description(ready_fn):
             '-l', performance_log_prefix_pub,
             '--rate', '5',
             '--roundtrip_mode', 'Main',
-            "--ignore", "3",
+            '--ignore', '3',
         ],
         additional_env={'RMW_IMPLEMENTATION': '@COMM_PUB@'},
     )
@@ -172,7 +172,7 @@ def generate_test_description(ready_fn):
             '-l', performance_log_prefix_sub,
             '--rate', '5',
             '--roundtrip_mode', 'Relay',
-            "--ignore", "3",
+            '--ignore', '3',
         ],
         additional_env={'RMW_IMPLEMENTATION': '@COMM_SUB@'},
     )
@@ -239,7 +239,7 @@ class PerformanceTestResults(unittest.TestCase):
             performance_report_csv = os.environ.get('PERFORMANCE_OVERHEAD_CSV')
             if performance_report_csv:
                 _raw_to_csv(performance_log_data, performance_log_perf_data,
-                            performance_report_csv, "pub")
+                            performance_report_csv, 'pub')
             else:
                 print('No CSV report written - set PERFORMANCE_OVERHEAD_CSV to write a report',
                       file=sys.stderr)
@@ -247,7 +247,7 @@ class PerformanceTestResults(unittest.TestCase):
             performance_report_png = os.environ.get('PERFORMANCE_OVERHEAD_PNG')
             if performance_report_png:
                 _raw_to_png(performance_log_data, performance_log_perf_data,
-                            performance_report_png, "publisher", "@COMM_PUB@")
+                            performance_report_png, 'publisher', '@COMM_PUB@')
             else:
                 print('No PNG report written - set PERFORMANCE_OVERHEAD_PNG to write a report',
                       file=sys.stderr)
@@ -265,7 +265,7 @@ class PerformanceTestResults(unittest.TestCase):
             performance_report_csv = os.environ.get('PERFORMANCE_OVERHEAD_CSV')
             if performance_report_csv:
                 _raw_to_csv(performance_log_data, performance_log_perf_data,
-                            performance_report_csv, "sub")
+                            performance_report_csv, 'sub')
             else:
                 print('No CSV report written - set PERFORMANCE_OVERHEAD_CSV to write a report',
                       file=sys.stderr)
@@ -273,7 +273,7 @@ class PerformanceTestResults(unittest.TestCase):
             performance_report_png = os.environ.get('PERFORMANCE_OVERHEAD_PNG')
             if performance_report_png:
                 _raw_to_png(performance_log_data, performance_log_perf_data,
-                            performance_report_png, "subscriber", "@COMM_SUB@")
+                            performance_report_png, 'subscriber', '@COMM_SUB@')
             else:
                 print('No PNG report written - set PERFORMANCE_OVERHEAD_PNG to write a report',
                       file=sys.stderr)

--- a/test/test_spinning.py.in
+++ b/test/test_spinning.py.in
@@ -115,8 +115,9 @@ class NodeSpinningTestTermination(unittest.TestCase):
 @launch_testing.post_shutdown_test()
 class NodeSpinningTestResults(unittest.TestCase):
 
-    def test_results_@TEST_NAME@(self, node_spinning_log_prefix,
-                                 node_metrics_collector, proc_info):
+    def test_results_@TEST_NAME@(
+            self, node_spinning_log_prefix,
+            node_metrics_collector, proc_info):
         self.addCleanup(_cleanUpLogs, node_spinning_log_prefix)
 
         launch_testing.asserts.assertExitCodes(
@@ -128,21 +129,24 @@ class NodeSpinningTestResults(unittest.TestCase):
         node_spinning_logs = glob(node_spinning_log_prefix + '*')
 
         if node_spinning_logs:
-            node_spinning_data = read_performance_test_csv(node_spinning_logs[0], start_marker=None)
+            node_spinning_data = read_performance_test_csv(
+                node_spinning_logs[0], start_marker=None)
 
             node_spinning_report_csv = os.environ.get('PERFORMANCE_OVERHEAD_NODE_CSV')
             if node_spinning_report_csv:
                 _raw_to_csv(node_spinning_data, node_spinning_report_csv)
             else:
-                print('No CSV report written - set PERFORMANCE_OVERHEAD_NODE_CSV to write a report',
-                      file=sys.stderr)
+                print(
+                    'No CSV report written - set PERFORMANCE_OVERHEAD_NODE_CSV to write a report',
+                    file=sys.stderr)
 
             node_spinning_report_png = os.environ.get('PERFORMANCE_OVERHEAD_NODE_PNG')
             if node_spinning_report_png:
                 _raw_to_png(node_spinning_data, node_spinning_report_png)
             else:
-                print('No PNG report written - set PERFORMANCE_OVERHEAD_NODE_PNG to write a report',
-                      file=sys.stderr)
+                print(
+                    'No PNG report written - set PERFORMANCE_OVERHEAD_NODE_PNG to write a report',
+                    file=sys.stderr)
         else:
             print('No report written - no performance log was produced',
                   file=sys.stderr)

--- a/test/test_spinning.py.in
+++ b/test/test_spinning.py.in
@@ -65,22 +65,22 @@ def _raw_to_png(dataframe, png_path):
 
     plt.title('Node spinning virtual memory usage\n@TEST_NAME@')
     plt.ylim(0, 1024)
-    plt.savefig(png_path[:-4] + "_virtual_memory.png")
+    plt.savefig(png_path[:-4] + '_virtual_memory.png')
 
     dataframe[['T_experiment', 'cpu_usage (%)']].plot(x='T_experiment')
     plt.title('Node spinning CPU usage\n@TEST_NAME@')
     plt.ylim(0, 100)
-    plt.savefig(png_path[:-4] + "_cpu_usage.png")
+    plt.savefig(png_path[:-4] + '_cpu_usage.png')
 
     dataframe[['T_experiment', 'physical memory (Mb)']].plot(x='T_experiment')
     plt.ylim(0, 100)
     plt.title('Node spinning physical memory usage\n@TEST_NAME@')
-    plt.savefig(png_path[:-4] + "_physical_memory.png")
+    plt.savefig(png_path[:-4] + '_physical_memory.png')
 
     dataframe[['T_experiment', 'resident anonymous memory (Mb)']].plot(x='T_experiment')
     plt.title('Node spinning resident anonymous memory\n@TEST_NAME@')
     plt.ylim(0, 100)
-    plt.savefig(png_path[:-4] + "_resident_anonymous_memory.png")
+    plt.savefig(png_path[:-4] + '_resident_anonymous_memory.png')
 
 
 def generate_test_description(ready_fn):


### PR DESCRIPTION
We can't run flake8 directly on the template files because the `@FOO@` tokens cause a syntax error. We can, however, run flake8 on the generated launch test files. Note that the line numbers won't change post-generation, but the lengths sometimes do. Some of the lines needed to be shorted by a lot in the template due to long test names, so if this change seems to aggressively shorten some of the lines, that is why.