### PR TITLE
Completely refactor the tests CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,8 @@ install(TARGETS node_spinning
   EXPORT export_${PROJECT_NAME}
   DESTINATION lib/${PROJECT_NAME})
 
-option(ENABLE_SYSTEM_METRIC_COLLECTOR "Enables the system metric collector and tests which use it" ${UNIX})
+option(ENABLE_SYSTEM_METRIC_COLLECTOR
+  "Enables the system metric collector and tests which use it" ${UNIX})
 if(ENABLE_SYSTEM_METRIC_COLLECTOR)
   add_executable(system_metric_collector
     src/linux_cpu_process_measurement.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,16 +1,12 @@
+#
+# Global performance test settings
+#
+
 set(PERF_TEST_MAX_RUNTIME 30
   CACHE STRING "Duration for each performance test run")
-
-find_package(ament_cmake_flake8 REQUIRED)
-find_package(launch_testing_ament_cmake REQUIRED)
-find_package(rmw_implementation_cmake REQUIRED)
-
-set(COMM_TYPE_rmw_cyclonedds_cpp "CycloneDDS")
-set(COMM_TYPE_rmw_fastrtps_cpp "FastRTPS")
-
 set(PERF_TEST_TOPIC_PUB_SUB Array60k
   CACHE STRING "perf_test topic used by pub/stub tests")
-set(TOPICS
+set(PERF_TEST_TOPICS
   Array1k
   Array4k
   Array16k
@@ -19,284 +15,101 @@ set(TOPICS
   PointCloud512k
   Array1m
   Array2m
+  CACHE STRING "List of perf_test topics to run tests with"
 )
+
+#
+# Standalone (non-ROS) performance test settings
+#
+
+set(PERF_TEST_COMM_TYPE_rmw_cyclonedds_cpp "CycloneDDS"
+  CACHE STRING "Standalone COMM type for rmw_cyclonedds_cpp")
+set(PERF_TEST_COMM_TYPE_rmw_fastrtps_cpp "FastRTPS"
+  CACHE STRING "Standalone COMM type for rmw_fastrtps_cpp")
+
+#
+# Special environment variable settings
+#
+
+# Fast-RTPS RMWs need some special env vars for sync mode
+get_filename_component(FASTRTPS_DEFAULT_PROFILES_FILE
+  "${CMAKE_CURRENT_SOURCE_DIR}/DEFAULT_FASTRTPS_PROFILES.xml" ABSOLUTE)
+set(PERF_TEST_ENV_rmw_fastrtps_cpp_sync
+  "RMW_FASTRTPS_USE_QOS_FROM_XML=1"
+  "FASTRTPS_DEFAULT_PROFILES_FILE=${FASTRTPS_DEFAULT_PROFILES_FILE}"
+)
+set(PERF_TEST_ENV_rmw_fastrtps_dynamic_cpp_sync
+  "RMW_FASTRTPS_USE_QOS_FROM_XML=1"
+  "FASTRTPS_DEFAULT_PROFILES_FILE=${FASTRTPS_DEFAULT_PROFILES_FILE}"
+)
+
+# ...and some EXTRA special env vars for multi-process sync mode
+get_filename_component(FASTRTPS_DEFAULT_PROFILES_TWO_PROCESSES_FILE
+  "${CMAKE_CURRENT_SOURCE_DIR}/DEFAULT_FASTRTPS_PROFILES_TWO_PROCESSES.xml" ABSOLUTE)
+set(PERF_TEST_ENV_two_processes_rmw_fastrtps_cpp_sync
+  "FASTRTPS_DEFAULT_PROFILES_FILE=${FASTRTPS_DEFAULT_PROFILES_TWO_PROCESSES_FILE}"
+)
+set(PERF_TEST_ENV_two_processes_rmw_fastrtps_dynamic_cpp_sync
+  "FASTRTPS_DEFAULT_PROFILES_FILE=${FASTRTPS_DEFAULT_PROFILES_TWO_PROCESSES_FILE}"
+)
+set(PERF_TEST_ENV_pub_sub_rmw_fastrtps_cpp_sync
+  "FASTRTPS_DEFAULT_PROFILES_FILE=${FASTRTPS_DEFAULT_PROFILES_TWO_PROCESSES_FILE}"
+)
+set(PERF_TEST_ENV_pub_sub_rmw_fastrtps_dynamic_cpp_sync
+  "FASTRTPS_DEFAULT_PROFILES_FILE=${FASTRTPS_DEFAULT_PROFILES_TWO_PROCESSES_FILE}"
+)
+
+#
+# Skipped test settings
+#
+
+# Some DDS/RMWs don't support async/sync
+set(PERF_TEST_SKIP_CycloneDDS_async ON
+  CACHE BOOL "Skip CycloneDDS async tests")
+set(PERF_TEST_SKIP_rmw_cyclonedds_cpp_async ON
+  CACHE BOOL "Skip rmw_cyclonedds_cpp async tests")
+set(PERF_TEST_SKIP_rmw_opensplice_cpp_sync ON
+  CACHE BOOL "Skip rmw_opensplice_cpp sync tests")
+set(PERF_TEST_SKIP_rmw_connext_cpp_sync ON
+  CACHE BOOL "Skip rmw_connext_cpp sync tests")
+
+# Fast-RTPS ros2-eloquent branch (1.9.3 + bugfixes) does not support synchronous
+# sending of fragments. This means that in that branch, topics PointCloud512k,
+# Array1m, and Array2m cannot be sent synchronously in ROS 2 Eloquent (either
+# from standalone Fast-RTPS, or from rmw_fastrtps_*)
+# https://github.com/ros2/buildfarm_perf_tests/pull/26#discussion_r393229707
+set(FASTRTPS_SYNC_SKIP_ROS_DISTROS
+  "dashing"
+  "eloquent"
+)
+if("$ENV{ROS_DISTRO}" IN_LIST FASTRTPS_SYNC_SKIP_ROS_DISTROS)
+  foreach(skip_rmw rmw_fastrtps_cpp rmw_fastrtps_dynamic_cpp FastRTPS)
+    foreach(skip_topic Array1m Array2m PointCloud512k)
+      set(PERF_TEST_SKIP_${skip_rmw}_sync_${skip_topic} ON
+        CACHE BOOL "Skip ${skip_rmw} sync ${skip_topic} tests")
+    endforeach()
+  endforeach()
+endif()
+
+# TODO (ahcorde): perf_test is not working with CycloneDDS when
+# processes are splitted in two
+# what(): Round trip mode is not implemented for Cyclone DDS!
+set(PERF_TEST_SKIP_two_process_CycloneDDS_async ON
+  CACHE BOOL "Skip two-process CycloneDDS async tests")
+set(PERF_TEST_SKIP_two_process_CycloneDDS_sync ON
+  CACHE BOOL "Skip two-process CycloneDDS sync tests")
+
+#
+# Add performance tests
+#
+
+find_package(ament_cmake_flake8 REQUIRED)
+find_package(launch_testing_ament_cmake REQUIRED)
+find_package(rmw_implementation_cmake REQUIRED)
 
 ament_flake8(TESTNAME "flake8_generated"
   ${CMAKE_CURRENT_BINARY_DIR}/test
 )
 
-function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
-
-  if(${SYNC_MODE} STREQUAL "async" AND ${RMW_IMPLEMENTATION} STREQUAL "rmw_cyclonedds_cpp")
-    message(STATUS "No async mode in RMW_IMPLEMENTATION: rmw_cyclonedds_cpp")
-    return()
-  endif()
-
-  if(${SYNC_MODE} STREQUAL "sync" AND ${RMW_IMPLEMENTATION} STREQUAL "rmw_opensplice_cpp")
-    message(STATUS "No sync mode in RMW_IMPLEMENTATION: rmw_opensplice_cpp")
-    return()
-  endif()
-
-  if(${SYNC_MODE} STREQUAL "sync" AND ${RMW_IMPLEMENTATION} STREQUAL "rmw_connext_cpp")
-    message(STATUS "No sync mode in RMW_IMPLEMENTATION: rmw_connext_cpp")
-    return()
-  endif()
-
-  # Enviroment variables to configure rmw_fastrtps_cpp in sync or async
-  if(${SYNC_MODE} STREQUAL "sync" AND
-    (${RMW_IMPLEMENTATION} STREQUAL "rmw_fastrtps_cpp" OR ${RMW_IMPLEMENTATION} STREQUAL "rmw_fastrtps_dynamic_cpp"))
-      set(RMW_FASTRTPS_USE_QOS_FROM_XML 1)
-      get_filename_component(
-          FASTRTPS_DEFAULT_PROFILES_FILE
-          "${CMAKE_CURRENT_SOURCE_DIR}/DEFAULT_FASTRTPS_PROFILES.xml"
-          ABSOLUTE
-      )
-      get_filename_component(
-          FASTRTPS_DEFAULT_PROFILES_TWO_PROCESSES_FILE
-          "${CMAKE_CURRENT_SOURCE_DIR}/DEFAULT_FASTRTPS_PROFILES_TWO_PROCESSES.xml"
-          ABSOLUTE
-      )
-  else()
-    set(RMW_FASTRTPS_USE_QOS_FROM_XML 0)
-    set(FASTRTPS_DEFAULT_PROFILES_FILE "")
-    set(FASTRTPS_DEFAULT_PROFILES_TWO_PROCESSES_FILE "")
-  endif()
-
-  foreach(topic ${TOPICS})
-
-    set(PERF_TEST_TOPIC ${topic})
-
-    # Fast-RTPS ros2-eloquent branch (1.9.3 + bugfixes) does not support synchronous
-    # sending of fragments. This means that in that branch, topics PointCloud512k,
-    # Array1m, and Array2m cannot be sent synchronously in ROS 2 Eloquent (either
-    # from standalone Fast-RTPS, or from rmw_fastrtps_*)
-    # https://github.com/ros2/buildfarm_perf_tests/pull/26#discussion_r393229707
-    set(SKIP_TEST "")
-    if(("$ENV{ROS_DISTRO}" STREQUAL "eloquent" OR "$ENV{ROS_DISTRO}" STREQUAL "dashing") AND (
-        ${TEST_NAME}_${PERF_TEST_TOPIC} STREQUAL "rmw_fastrtps_cpp_sync_Array2m" OR
-        ${TEST_NAME}_${PERF_TEST_TOPIC} STREQUAL "rmw_fastrtps_cpp_sync_Array1m" OR
-        ${TEST_NAME}_${PERF_TEST_TOPIC} STREQUAL "rmw_fastrtps_cpp_sync_PointCloud512k" OR
-        ${TEST_NAME}_${PERF_TEST_TOPIC} STREQUAL "rmw_fastrtps_dynamic_cpp_sync_Array2m" OR
-        ${TEST_NAME}_${PERF_TEST_TOPIC} STREQUAL "rmw_fastrtps_dynamic_cpp_sync_Array1m" OR
-        ${TEST_NAME}_${PERF_TEST_TOPIC} STREQUAL "rmw_fastrtps_dynamic_cpp_sync_PointCloud512k" OR
-        ${TEST_NAME}_${PERF_TEST_TOPIC} STREQUAL "FastRTPS_sync_Array2m" OR
-        ${TEST_NAME}_${PERF_TEST_TOPIC} STREQUAL "FastRTPS_sync_Array1m" OR
-        ${TEST_NAME}_${PERF_TEST_TOPIC} STREQUAL "FastRTPS_sync_PointCloud512k"
-      ))
-      set(SKIP_TEST "SKIP_TEST")
-    endif()
-
-    set(NUMBER_PROCESS "1")
-    get_filename_component(
-      PERFORMANCE_REPORT_PNG
-      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/performance_test_results_${TEST_NAME}_${PERF_TEST_TOPIC}.png"
-      ABSOLUTE
-    )
-    get_filename_component(
-      PERFORMANCE_REPORT_CSV
-      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/performance_test_results_${TEST_NAME}_${PERF_TEST_TOPIC}.csv"
-      ABSOLUTE
-    )
-    configure_file(
-      test_performance.py.in
-      ${CMAKE_CURRENT_BINARY_DIR}/test_performance_${TEST_NAME}_${PERF_TEST_TOPIC}.py.configure
-      @ONLY
-    )
-    file(GENERATE
-      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test/test_performance_${TEST_NAME}_${PERF_TEST_TOPIC}.py"
-      INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_performance_${TEST_NAME}_${PERF_TEST_TOPIC}.py.configure"
-    )
-    add_launch_test(
-      "${CMAKE_CURRENT_BINARY_DIR}/test/test_performance_${TEST_NAME}_${PERF_TEST_TOPIC}.py"
-      TARGET test_performance_${TEST_NAME}_${PERF_TEST_TOPIC}
-      ENV
-      "PERFORMANCE_REPORT_PNG=${PERFORMANCE_REPORT_PNG}"
-      "PERFORMANCE_REPORT_CSV=${PERFORMANCE_REPORT_CSV}"
-      "RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}"
-      "RMW_FASTRTPS_USE_QOS_FROM_XML=${RMW_FASTRTPS_USE_QOS_FROM_XML}"
-      "FASTRTPS_DEFAULT_PROFILES_FILE=${FASTRTPS_DEFAULT_PROFILES_FILE}"
-      ${SKIP_TEST}
-    )
-    set_tests_properties(test_performance_${TEST_NAME}_${PERF_TEST_TOPIC} PROPERTIES
-      RUN_SERIAL TRUE
-      LABELS "performance"
-    )
-
-    set(NUMBER_PROCESS "2")
-    # TODO (ahcorde): perf_test is not working with CycloneDDS when
-    # processes are splitted in two
-    if(${COMM} STREQUAL "CycloneDDS")
-      set(SKIP_TEST "SKIP_TEST")
-    endif()
-
-    get_filename_component(
-      PERFORMANCE_TWO_PROCESS_REPORT_PNG
-      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/performance_test_two_process_results_${TEST_NAME}_${PERF_TEST_TOPIC}.png"
-      ABSOLUTE
-    )
-    get_filename_component(
-      PERFORMANCE_TWO_PROCESS_REPORT_CSV
-      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/performance_test_two_process_results_${TEST_NAME}_${PERF_TEST_TOPIC}.csv"
-      ABSOLUTE
-    )
-    configure_file(
-      test_performance.py.in
-      ${CMAKE_CURRENT_BINARY_DIR}/test_performance_two_process_${TEST_NAME}_${PERF_TEST_TOPIC}.py.configure
-      @ONLY
-    )
-    file(GENERATE
-      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test/test_performance_two_process_${TEST_NAME}_${PERF_TEST_TOPIC}.py"
-      INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_performance_two_process_${TEST_NAME}_${PERF_TEST_TOPIC}.py.configure"
-    )
-
-    add_launch_test(
-      "${CMAKE_CURRENT_BINARY_DIR}/test/test_performance_two_process_${TEST_NAME}_${PERF_TEST_TOPIC}.py"
-      TARGET test_performance_two_process_${TEST_NAME}_${PERF_TEST_TOPIC}
-      ENV
-      "PERFORMANCE_REPORT_PNG=${PERFORMANCE_TWO_PROCESS_REPORT_PNG}"
-      "PERFORMANCE_REPORT_CSV=${PERFORMANCE_TWO_PROCESS_REPORT_CSV}"
-      "RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}"
-      "RMW_FASTRTPS_USE_QOS_FROM_XML=${RMW_FASTRTPS_USE_QOS_FROM_XML}"
-      "FASTRTPS_DEFAULT_PROFILES_FILE=${FASTRTPS_DEFAULT_PROFILES_TWO_PROCESSES_FILE}"
-      ${SKIP_TEST}
-    )
-    set_tests_properties(test_performance_two_process_${TEST_NAME}_${PERF_TEST_TOPIC} PROPERTIES
-      RUN_SERIAL TRUE
-      LABELS "performance"
-    )
-  endforeach()
-
-  if(NOT "${COMM}" STREQUAL "ROS2")
-    return()
-  endif()
-
-  set(NODE_SPINNING_TIMEOUT "30")
-  get_filename_component(
-    PERFORMANCE_OVERHEAD_NODE_CSV
-    "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/overhead_node_test_results_${TEST_NAME}.csv"
-    ABSOLUTE
-  )
-  get_filename_component(
-    PERFORMANCE_OVERHEAD_NODE_PNG
-    "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/overhead_node_test_results_${TEST_NAME}.png"
-    ABSOLUTE
-  )
-
-  configure_file(
-    test_spinning.py.in
-    ${CMAKE_CURRENT_BINARY_DIR}/test_spinning_${TEST_NAME}.py.configure
-    @ONLY
-  )
-  file(GENERATE
-    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test/test_spinning_${TEST_NAME}.py"
-    INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_spinning_${TEST_NAME}.py.configure"
-  )
-
-  add_launch_test(
-    "${CMAKE_CURRENT_BINARY_DIR}/test/test_spinning_${TEST_NAME}.py"
-    TARGET test_spinning_${TEST_NAME}
-    ENV
-    "PERFORMANCE_OVERHEAD_NODE_CSV=${PERFORMANCE_OVERHEAD_NODE_CSV}"
-    "PERFORMANCE_OVERHEAD_NODE_PNG=${PERFORMANCE_OVERHEAD_NODE_PNG}"
-    "RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}"
-    "RMW_FASTRTPS_USE_QOS_FROM_XML=${RMW_FASTRTPS_USE_QOS_FROM_XML}"
-    "FASTRTPS_DEFAULT_PROFILES_FILE=${FASTRTPS_DEFAULT_PROFILES_FILE}"
-    TIMEOUT 120
-  )
-  set_tests_properties(test_spinning_${TEST_NAME} PROPERTIES
-    RUN_SERIAL TRUE
-    LABELS "performance"
-  )
-  set(PUBSUB_TIMEOUT "30")
-  set(PERF_TEST_TOPIC ${PERF_TEST_TOPIC_PUB_SUB})
-
-  get_available_rmw_implementations(_rmw_implementations)
-
-  foreach(rmw_impl ${_rmw_implementations})
-
-    # TODO (ahcorde): perf_test is not working with CycloneDDS when
-    #  processes are splitted in two
-    # what(): Round tip mode is not implemented for Cyclone DDS
-    set(SKIP_TEST "")
-    if(${COMM} STREQUAL "CycloneDDS")
-      set(SKIP_TEST "SKIP_TEST")
-    endif()
-
-    set(COMM_PUB ${RMW_IMPLEMENTATION})
-    set(COMM_SUB ${rmw_impl})
-    set(TEST_NAME_PUB_SUB ${TEST_NAME}_${rmw_impl}_${COMM})
-
-    get_filename_component(
-      PERFORMANCE_OVERHEAD_CSV
-      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/overhead_test_results_${TEST_NAME_PUB_SUB}.csv"
-      ABSOLUTE
-    )
-    get_filename_component(
-      PERFORMANCE_OVERHEAD_PNG
-      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/overhead_test_results_${TEST_NAME_PUB_SUB}.png"
-      ABSOLUTE
-    )
-
-    configure_file(
-      test_pub_sub.py.in
-      ${CMAKE_CURRENT_BINARY_DIR}/test_pub_sub_${TEST_NAME_PUB_SUB}.py.configure
-      @ONLY
-    )
-    file(GENERATE
-      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test/test_pub_sub_${TEST_NAME_PUB_SUB}.py"
-      INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_pub_sub_${TEST_NAME_PUB_SUB}.py.configure"
-    )
-
-    add_launch_test(
-      "${CMAKE_CURRENT_BINARY_DIR}/test/test_pub_sub_${TEST_NAME_PUB_SUB}.py"
-      TARGET test_pub_sub_${TEST_NAME_PUB_SUB}
-      ENV
-      "PERFORMANCE_OVERHEAD_CSV=${PERFORMANCE_OVERHEAD_CSV}"
-      "PERFORMANCE_OVERHEAD_PNG=${PERFORMANCE_OVERHEAD_PNG}"
-      "RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}"
-      "RMW_FASTRTPS_USE_QOS_FROM_XML=${RMW_FASTRTPS_USE_QOS_FROM_XML}"
-      "FASTRTPS_DEFAULT_PROFILES_FILE=${FASTRTPS_DEFAULT_PROFILES_TWO_PROCESSES_FILE}"
-      TIMEOUT 120
-      ${SKIP_TEST}
-    )
-    set_tests_properties(test_pub_sub_${TEST_NAME_PUB_SUB} PROPERTIES
-      RUN_SERIAL TRUE
-      LABELS "performance"
-    )
-  endforeach()
-endfunction()
-
-macro(try_add_performance_test)
-  add_performance_test(
-    "${rmw_implementation}_async"
-    "ROS2"
-    ${rmw_implementation}
-    "async"
-  )
-
-  add_performance_test(
-    "${rmw_implementation}_sync"
-    "ROS2"
-    ${rmw_implementation}
-    "sync"
-  )
-
-  if(COMM_TYPE_${rmw_implementation})
-    add_performance_test(
-      "${COMM_TYPE_${rmw_implementation}}_async"
-      ${COMM_TYPE_${rmw_implementation}}
-      ${rmw_implementation}
-      "async"
-    )
-    add_performance_test(
-      "${COMM_TYPE_${rmw_implementation}}_sync"
-      ${COMM_TYPE_${rmw_implementation}}
-      ${rmw_implementation}
-      "sync"
-    )
-  else()
-    message(STATUS "No standalone DDS support for RMW: ${rmw_implementation}")
-  endif()
-endmacro()
-
-call_for_each_rmw_implementation(try_add_performance_test)
+include(add_performance_tests.cmake)
+call_for_each_rmw_implementation(add_performance_tests)

--- a/test/add_performance_tests.cmake
+++ b/test/add_performance_tests.cmake
@@ -12,6 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#
+# Add performance tests for a single COMM/RMW type.
+#
+# Adds the following tests:
+#   1. Apex.AI perf_test for every topic defined in ``PERF_TEST_TOPICS``
+#   2. Same as (1.), but using separate publisher and subscriber processes
+#   3. Standalone spinner/overhead test (Only for ``ROS2`` COMM)
+#   4. Cross-vendor publisher/subscriber tests for each other RMW implementation
+#      (Only for ``ROS2`` COMM)
+#
+# :param TEST_NAME: The name the test, used in the resulting test report, output
+#   artifacts and behavior augmentation variable names.
+# :type TEST_NAME: string
+# :param COMM: The Apex.AI ``performance_test`` ``COMM`` type (e.x. ``ROS2``).
+# :type COMM: string
+# :param RMW_IMPLEMENTATION: The RMW implementation for use when ``COMM`` is set
+#   to ``ROS2``.
+# :type RMW_IMPLEMENTATION: string
+# :param SYNC_MODE: One of ``async`` or ``sync``.
+# :type SYNC_MODE: string
+#
+# All of the behavior augmentations documented for
+# :cmake:macro:`add_performance_tests` also apply to this function.
+#
 function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
 
   #
@@ -271,6 +295,33 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
 
 endfunction()
 
+#
+# Add performance tests for all available RMW implementations and all sandalone
+# DDS implmenetations associated with those RMWs by invoking
+# :cmake:macro:`add_performance_test` on each of them.
+#
+# The following values, when defined prior to invocation, will augment the
+# behavior of the tests:
+#
+# - **PERF_TEST_COMM_TYPE_${RMW}** *(string)* – Specifies a standalone
+#   ``COMM`` type that is associated with the given ``RMW``. If undefined or set
+#   to an empty string, no standalone test is added.
+# - **PERF_TEST_SKIP[_pub_sub|_two_process]_${COMM_OR_RMW}[_${SYNC_MODE}[_${TOPIC_NAME}]]**
+#   *(bool)* – Specifies that matching tests should be automatically skipped.
+# - **PERF_TEST_ENV[_pub_sub|_two_process]_${COMM_OR_RMW}[_${SYNC_MODE}[_${TOPIC_NAME}]]**
+#   *(list of "key=value")* – Specifies additional environment variables to
+#   add to matching tests.
+#
+# Examples:
+#   ``PERF_TEST_COMM_TYPE_rmw_cyclonedds_cpp=CycloneDDS``
+#     An additional standalone ``COMM`` type called ``CycloneDDS`` should be run
+#     if ``rmw_cyclonedds_cpp`` is found and run.
+#   ``PERF_TEST_SKIP_rmw_connext_cpp_sync=TRUE``
+#     Automatically skip all synchronous tests for ``rmw_cyclonedds_cpp``.
+#   ``PERF_TEST_ENV_rmw_fastrtps_cpp_sync="RMW_FASTRTPS_USE_QOS_FROM_XML=1"``
+#     Set the environment variable ``RMW_FASTRTPS_USE_QOS_FROM_XML`` to ``1``
+#     whenever synchronous tests are run for ``rmw_fastrtps_cpp``.
+#
 macro(add_performance_tests)
   foreach(PERF_TEST_SYNC "async" "sync")
     add_performance_test(

--- a/test/add_performance_tests.cmake
+++ b/test/add_performance_tests.cmake
@@ -91,13 +91,15 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
     )
 
     configure_file(
-      test_performance.py.in
-      ${CMAKE_CURRENT_BINARY_DIR}/test_performance_${TEST_NAME_SYNC_TOPIC}.py.configure
+      "test_performance.py.in"
+      "${CMAKE_CURRENT_BINARY_DIR}/test_performance_${TEST_NAME_SYNC_TOPIC}.py.configure"
       @ONLY
     )
     file(GENERATE
-      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test/test_performance_${TEST_NAME_SYNC_TOPIC}.py"
-      INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_performance_${TEST_NAME_SYNC_TOPIC}.py.configure"
+      OUTPUT
+      "${CMAKE_CURRENT_BINARY_DIR}/test/test_performance_${TEST_NAME_SYNC_TOPIC}.py"
+      INPUT
+      "${CMAKE_CURRENT_BINARY_DIR}/test_performance_${TEST_NAME_SYNC_TOPIC}.py.configure"
     )
     add_launch_test(
       "${CMAKE_CURRENT_BINARY_DIR}/test/test_performance_${TEST_NAME_SYNC_TOPIC}.py"
@@ -115,11 +117,14 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
     if(NOT SKIP_TEST_TOPIC)
       if(PERF_TEST_SKIP_two_process_${TEST_NAME_SYNC_TOPIC} OR
           PERF_TEST_SKIP_two_process_${TEST_NAME_SYNC})
-        message(STATUS "Skipping performance tests: two_process_${TEST_NAME_SYNC_TOPIC}")
+        message(STATUS
+          "Skipping performance tests: two_process_${TEST_NAME_SYNC_TOPIC}")
         set(SKIP_TEST_TOPIC "SKIP_TEST")
       endif()
     endif()
-    list(APPEND TEST_ENV_TOPIC ${PERF_TEST_ENV_two_process_${TEST_NAME_SYNC_TOPIC}})
+    list(APPEND TEST_ENV_TOPIC
+      ${PERF_TEST_ENV_two_process_${TEST_NAME_SYNC_TOPIC}}
+    )
 
     set(NUMBER_PROCESS "2")
 
@@ -139,13 +144,15 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
     )
 
     configure_file(
-      test_performance.py.in
-      ${CMAKE_CURRENT_BINARY_DIR}/test_performance_two_process_${TEST_NAME_SYNC_TOPIC}.py.configure
+      "test_performance.py.in"
+      "${CMAKE_CURRENT_BINARY_DIR}/test_performance_two_process_${TEST_NAME_SYNC_TOPIC}.py.configure"
       @ONLY
     )
     file(GENERATE
-      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test/test_performance_two_process_${TEST_NAME_SYNC_TOPIC}.py"
-      INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_performance_two_process_${TEST_NAME_SYNC_TOPIC}.py.configure"
+      OUTPUT
+      "${CMAKE_CURRENT_BINARY_DIR}/test/test_performance_two_process_${TEST_NAME_SYNC_TOPIC}.py"
+      INPUT
+      "${CMAKE_CURRENT_BINARY_DIR}/test_performance_two_process_${TEST_NAME_SYNC_TOPIC}.py.configure"
     )
 
     add_launch_test(
@@ -154,7 +161,8 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
       ENV ${TEST_ENV_TOPIC}
       ${SKIP_TEST_TOPIC}
     )
-    set_tests_properties(test_performance_two_process_${TEST_NAME_SYNC_TOPIC} PROPERTIES
+    set_tests_properties(
+      test_performance_two_process_${TEST_NAME_SYNC_TOPIC} PROPERTIES
       RUN_SERIAL TRUE
       LABELS "performance"
     )
@@ -165,7 +173,8 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
   #
 
   if(NOT "${COMM}" STREQUAL "ROS2")
-    # Since standalone DDS can never run correctly, exclude instead of skipping the tests.
+    # Since standalone DDS can never run correctly,
+    # exclude instead of skipping the tests.
     return()
   endif()
 
@@ -175,7 +184,9 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
 
   if(NOT ENABLE_SYSTEM_METRIC_COLLECTOR)
     set(SKIP_TEST "SKIP_TEST")
-    message(STATUS "Skipping performance tests: ${TEST_NAME_SYNC} (no system_metric_collector)")
+    message(STATUS
+      "Skipping performance tests: ${TEST_NAME_SYNC}"
+      " (no system_metric_collector)")
   endif()
 
   #
@@ -211,13 +222,15 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
   )
 
   configure_file(
-    test_spinning.py.in
+    "test_spinning.py.in"
     ${CMAKE_CURRENT_BINARY_DIR}/test_spinning_${TEST_NAME_SYNC}.py.configure
     @ONLY
   )
   file(GENERATE
-    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test/test_spinning_${TEST_NAME_SYNC}.py"
-    INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_spinning_${TEST_NAME_SYNC}.py.configure"
+    OUTPUT
+    "${CMAKE_CURRENT_BINARY_DIR}/test/test_spinning_${TEST_NAME_SYNC}.py"
+    INPUT
+    "${CMAKE_CURRENT_BINARY_DIR}/test_spinning_${TEST_NAME_SYNC}.py.configure"
   )
 
   add_launch_test(
@@ -244,8 +257,10 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
     set(TEST_NAME_PUB_SUB "${TEST_NAME_SYNC}_${RMW_IMPLEMENTATION_SUB}_${COMM}")
     set(SKIP_TEST_PUB_SUB "${SKIP_TEST}")
     if(NOT SKIP_TEST_PUB_SUB)
-      if(PERF_TEST_SKIP_${TEST_NAME_PUB_SUB} OR PERF_TEST_SKIP_pub_sub_${TEST_NAME_SYNC} OR
-          PERF_TEST_SKIP_pub_sub OR PERF_TEST_SKIP_apex_ai_suite OR NOT ENABLE_SYSTEM_METRIC_COLLECTOR)
+      if(PERF_TEST_SKIP_${TEST_NAME_PUB_SUB} OR
+          PERF_TEST_SKIP_pub_sub_${TEST_NAME_SYNC} OR
+          PERF_TEST_SKIP_pub_sub OR PERF_TEST_SKIP_apex_ai_suite OR
+          NOT ENABLE_SYSTEM_METRIC_COLLECTOR)
         message(STATUS "Skipping performance tests: ${TEST_NAME_PUB_SUB}")
         set(SKIP_TEST_PUB_SUB "SKIP_TEST")
       endif()
@@ -271,13 +286,15 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
     )
 
     configure_file(
-      test_pub_sub.py.in
+      "test_pub_sub.py.in"
       ${CMAKE_CURRENT_BINARY_DIR}/test_pub_sub_${TEST_NAME_PUB_SUB}.py.configure
       @ONLY
     )
     file(GENERATE
-      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test/test_pub_sub_${TEST_NAME_PUB_SUB}.py"
-      INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_pub_sub_${TEST_NAME_PUB_SUB}.py.configure"
+      OUTPUT
+      "${CMAKE_CURRENT_BINARY_DIR}/test/test_pub_sub_${TEST_NAME_PUB_SUB}.py"
+      INPUT
+      "${CMAKE_CURRENT_BINARY_DIR}/test_pub_sub_${TEST_NAME_PUB_SUB}.py.configure"
     )
 
     add_launch_test(
@@ -306,9 +323,9 @@ endfunction()
 # - **PERF_TEST_COMM_TYPE_${RMW}** *(string)* – Specifies a standalone
 #   ``COMM`` type that is associated with the given ``RMW``. If undefined or set
 #   to an empty string, no standalone test is added.
-# - **PERF_TEST_SKIP[_pub_sub|_two_process]_${COMM_OR_RMW}[_${SYNC_MODE}[_${TOPIC_NAME}]]**
+# - **PERF_TEST_SKIP[_${TYPE}]_${COMM_OR_RMW}[_${SYNC_MODE}[_${TOPIC_NAME}]]**
 #   *(bool)* – Specifies that matching tests should be automatically skipped.
-# - **PERF_TEST_ENV[_pub_sub|_two_process]_${COMM_OR_RMW}[_${SYNC_MODE}[_${TOPIC_NAME}]]**
+# - **PERF_TEST_ENV[_${TYPE}]_${COMM_OR_RMW}[_${SYNC_MODE}[_${TOPIC_NAME}]]**
 #   *(list of "key=value")* – Specifies additional environment variables to
 #   add to matching tests.
 #

--- a/test/add_performance_tests.cmake
+++ b/test/add_performance_tests.cmake
@@ -1,0 +1,296 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
+
+  #
+  # Setup for performance sub-tests
+  #
+
+  set(TEST_NAME_SYNC "${TEST_NAME}_${SYNC_MODE}")
+  set(SKIP_TEST "")
+  if(PERF_TEST_SKIP_${TEST_NAME_SYNC})
+    message(STATUS "Skipping performance tests: ${TEST_NAME_SYNC}")
+    set(SKIP_TEST "SKIP_TEST")
+  endif()
+
+  set(TEST_ENV "")
+  if(COMM STREQUAL "ROS2")
+    list(APPEND TEST_ENV "RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}")
+  endif()
+  list(APPEND TEST_ENV ${PERF_TEST_ENV_${TEST_NAME_SYNC}})
+
+  #
+  # Setup for per-topic tests
+  #
+
+  foreach(PERF_TEST_TOPIC ${PERF_TEST_TOPICS})
+    # Start with single-process tests
+
+    set(TEST_NAME_SYNC_TOPIC "${TEST_NAME_SYNC}_${PERF_TEST_TOPIC}")
+    set(SKIP_TEST_TOPIC "${SKIP_TEST}")
+    if(NOT SKIP_TEST_TOPIC)
+      if(PERF_TEST_SKIP_${TEST_NAME_SYNC_TOPIC} OR PERF_TEST_SKIP_apex_ai_suite)
+        message(STATUS "Skipping performance tests: ${TEST_NAME_SYNC_TOPIC}")
+        set(SKIP_TEST_TOPIC "SKIP_TEST")
+      endif()
+    endif()
+    set(TEST_ENV_TOPIC ${TEST_ENV})
+    list(APPEND TEST_ENV_TOPIC ${PERF_TEST_ENV_${TEST_NAME_SYNC_TOPIC}})
+
+    set(NUMBER_PROCESS "1")
+
+    get_filename_component(
+      PERFORMANCE_REPORT_PNG
+      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/performance_test_results_${TEST_NAME_SYNC_TOPIC}.png"
+      ABSOLUTE
+    )
+    get_filename_component(
+      PERFORMANCE_REPORT_CSV
+      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/performance_test_results_${TEST_NAME_SYNC_TOPIC}.csv"
+      ABSOLUTE
+    )
+    list(APPEND TEST_ENV_TOPIC
+      "PERFORMANCE_REPORT_PNG=${PERFORMANCE_REPORT_PNG}"
+      "PERFORMANCE_REPORT_CSV=${PERFORMANCE_REPORT_CSV}"
+    )
+
+    configure_file(
+      test_performance.py.in
+      ${CMAKE_CURRENT_BINARY_DIR}/test_performance_${TEST_NAME_SYNC_TOPIC}.py.configure
+      @ONLY
+    )
+    file(GENERATE
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test/test_performance_${TEST_NAME_SYNC_TOPIC}.py"
+      INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_performance_${TEST_NAME_SYNC_TOPIC}.py.configure"
+    )
+    add_launch_test(
+      "${CMAKE_CURRENT_BINARY_DIR}/test/test_performance_${TEST_NAME_SYNC_TOPIC}.py"
+      TARGET test_performance_${TEST_NAME_SYNC_TOPIC}
+      ENV ${TEST_ENV_TOPIC}
+      ${SKIP_TEST_TOPIC}
+    )
+    set_tests_properties(test_performance_${TEST_NAME_SYNC_TOPIC} PROPERTIES
+      RUN_SERIAL TRUE
+      LABELS "performance"
+    )
+
+    # Inherit settings from single-process to run two-process tests
+
+    if(NOT SKIP_TEST_TOPIC)
+      if(PERF_TEST_SKIP_two_process_${TEST_NAME_SYNC_TOPIC} OR
+          PERF_TEST_SKIP_two_process_${TEST_NAME_SYNC})
+        message(STATUS "Skipping performance tests: two_process_${TEST_NAME_SYNC_TOPIC}")
+        set(SKIP_TEST_TOPIC "SKIP_TEST")
+      endif()
+    endif()
+    list(APPEND TEST_ENV_TOPIC ${PERF_TEST_ENV_two_process_${TEST_NAME_SYNC_TOPIC}})
+
+    set(NUMBER_PROCESS "2")
+
+    get_filename_component(
+      PERFORMANCE_REPORT_PNG
+      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/performance_test_two_process_results_${TEST_NAME_SYNC_TOPIC}.png"
+      ABSOLUTE
+    )
+    get_filename_component(
+      PERFORMANCE_REPORT_CSV
+      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/performance_test_two_process_results_${TEST_NAME_SYNC_TOPIC}.csv"
+      ABSOLUTE
+    )
+    list(APPEND TEST_ENV_TOPIC
+      "PERFORMANCE_REPORT_PNG=${PERFORMANCE_REPORT_PNG}"
+      "PERFORMANCE_REPORT_CSV=${PERFORMANCE_REPORT_CSV}"
+    )
+
+    configure_file(
+      test_performance.py.in
+      ${CMAKE_CURRENT_BINARY_DIR}/test_performance_two_process_${TEST_NAME_SYNC_TOPIC}.py.configure
+      @ONLY
+    )
+    file(GENERATE
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test/test_performance_two_process_${TEST_NAME_SYNC_TOPIC}.py"
+      INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_performance_two_process_${TEST_NAME_SYNC_TOPIC}.py.configure"
+    )
+
+    add_launch_test(
+      "${CMAKE_CURRENT_BINARY_DIR}/test/test_performance_two_process_${TEST_NAME_SYNC_TOPIC}.py"
+      TARGET test_performance_two_process_${TEST_NAME_SYNC_TOPIC}
+      ENV ${TEST_ENV_TOPIC}
+      ${SKIP_TEST_TOPIC}
+    )
+    set_tests_properties(test_performance_two_process_${TEST_NAME_SYNC_TOPIC} PROPERTIES
+      RUN_SERIAL TRUE
+      LABELS "performance"
+    )
+  endforeach()
+
+  #
+  # All remaining tests only apply to RMWs
+  #
+
+  if(NOT "${COMM}" STREQUAL "ROS2")
+    # Since standalone DDS can never run correctly, exclude instead of skipping the tests.
+    return()
+  endif()
+
+  #
+  # All remaining tests require the system_metric_collector
+  #
+
+  if(NOT ENABLE_SYSTEM_METRIC_COLLECTOR)
+    set(SKIP_TEST "SKIP_TEST")
+    message(STATUS "Skipping performance tests: ${TEST_NAME_SYNC} (no system_metric_collector)")
+  endif()
+
+  #
+  # Setup for spinning tests
+  #
+
+  set(SKIP_TEST_SPINNING "${SKIP_TEST}")
+  if(NOT SKIP_TEST_SPINNING)
+    if(PERF_TEST_SKIP_spinning_${TEST_NAME_SYNC} OR
+        PERF_TEST_SKIP_spinning OR NOT ENABLE_SYSTEM_METRIC_COLLECTOR)
+      message(STATUS "Skipping performance tests: spinning_${TEST_NAME_SYNC}")
+      set(SKIP_TEST_SPINNING "SKIP_TEST")
+    endif()
+  endif()
+  set(TEST_ENV_SPINNING ${TEST_ENV})
+  list(APPEND TEST_ENV_SPINNING ${PERF_TEST_ENV_spinning_${TEST_NAME_SYNC}})
+
+  set(NODE_SPINNING_TIMEOUT "30")
+
+  get_filename_component(
+    PERFORMANCE_OVERHEAD_NODE_CSV
+    "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/overhead_node_test_results_${TEST_NAME_SYNC}.csv"
+    ABSOLUTE
+  )
+  get_filename_component(
+    PERFORMANCE_OVERHEAD_NODE_PNG
+    "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/overhead_node_test_results_${TEST_NAME_SYNC}.png"
+    ABSOLUTE
+  )
+  list(APPEND TEST_ENV_SPINNING
+    "PERFORMANCE_OVERHEAD_NODE_CSV=${PERFORMANCE_OVERHEAD_NODE_CSV}"
+    "PERFORMANCE_OVERHEAD_NODE_PNG=${PERFORMANCE_OVERHEAD_NODE_PNG}"
+  )
+
+  configure_file(
+    test_spinning.py.in
+    ${CMAKE_CURRENT_BINARY_DIR}/test_spinning_${TEST_NAME_SYNC}.py.configure
+    @ONLY
+  )
+  file(GENERATE
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test/test_spinning_${TEST_NAME_SYNC}.py"
+    INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_spinning_${TEST_NAME_SYNC}.py.configure"
+  )
+
+  add_launch_test(
+    "${CMAKE_CURRENT_BINARY_DIR}/test/test_spinning_${TEST_NAME_SYNC}.py"
+    TARGET test_spinning_${TEST_NAME_SYNC}
+    ENV ${TEST_ENV_SPINNING}
+    TIMEOUT 120
+    ${SKIP_TEST_SPINNING}
+  )
+  set_tests_properties(test_spinning_${TEST_NAME_SYNC} PROPERTIES
+    RUN_SERIAL TRUE
+    LABELS "performance"
+  )
+
+  #
+  # Setup for cross-vendor tests
+  #
+
+  set(PUBSUB_TIMEOUT "30")
+  set(PERF_TEST_TOPIC ${PERF_TEST_TOPIC_PUB_SUB})
+  get_available_rmw_implementations(_rmw_implementations)
+  foreach(RMW_IMPLEMENTATION_SUB ${_rmw_implementations})
+    # TODO: Why is ${COMM} on the end here? It's always ROS2.
+    set(TEST_NAME_PUB_SUB "${TEST_NAME_SYNC}_${RMW_IMPLEMENTATION_SUB}_${COMM}")
+    set(SKIP_TEST_PUB_SUB "${SKIP_TEST}")
+    if(NOT SKIP_TEST_PUB_SUB)
+      if(PERF_TEST_SKIP_${TEST_NAME_PUB_SUB} OR PERF_TEST_SKIP_pub_sub_${TEST_NAME_SYNC} OR
+          PERF_TEST_SKIP_pub_sub OR PERF_TEST_SKIP_apex_ai_suite OR NOT ENABLE_SYSTEM_METRIC_COLLECTOR)
+        message(STATUS "Skipping performance tests: ${TEST_NAME_PUB_SUB}")
+        set(SKIP_TEST_PUB_SUB "SKIP_TEST")
+      endif()
+    endif()
+    set(TEST_ENV_PUB_SUB ${TEST_ENV})
+    list(APPEND TEST_ENV_PUB_SUB ${PERF_TEST_ENV_pub_sub_${TEST_NAME_SYNC}})
+    list(APPEND TEST_ENV_PUB_SUB ${PERF_TEST_ENV_${TEST_NAME_PUB_SUB}})
+
+    get_filename_component(
+      PERFORMANCE_OVERHEAD_CSV
+      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/overhead_test_results_${TEST_NAME_PUB_SUB}.csv"
+      ABSOLUTE
+    )
+    # TODO: Why doesn't this file name have a suffix?
+    get_filename_component(
+      PERFORMANCE_OVERHEAD_PNG
+      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/overhead_test_results"
+      ABSOLUTE
+    )
+    list(APPEND TEST_ENV_PUB_SUB
+      "PERFORMANCE_OVERHEAD_CSV=${PERFORMANCE_OVERHEAD_CSV}"
+      "PERFORMANCE_OVERHEAD_PNG=${PERFORMANCE_OVERHEAD_PNG}"
+    )
+
+    configure_file(
+      test_pub_sub.py.in
+      ${CMAKE_CURRENT_BINARY_DIR}/test_pub_sub_${TEST_NAME_PUB_SUB}.py.configure
+      @ONLY
+    )
+    file(GENERATE
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test/test_pub_sub_${TEST_NAME_PUB_SUB}.py"
+      INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_pub_sub_${TEST_NAME_PUB_SUB}.py.configure"
+    )
+
+    add_launch_test(
+      "${CMAKE_CURRENT_BINARY_DIR}/test/test_pub_sub_${TEST_NAME_PUB_SUB}.py"
+      TARGET test_pub_sub_${TEST_NAME_PUB_SUB}
+      ENV ${TEST_ENV_PUB_SUB}
+      TIMEOUT 120
+      ${SKIP_TEST_PUB_SUB}
+    )
+    set_tests_properties(test_pub_sub_${TEST_NAME_PUB_SUB} PROPERTIES
+      RUN_SERIAL TRUE
+      LABELS "performance"
+    )
+  endforeach()
+
+endfunction()
+
+macro(add_performance_tests)
+  foreach(PERF_TEST_SYNC "async" "sync")
+    add_performance_test(
+      ${rmw_implementation}
+      "ROS2"
+      ${rmw_implementation}
+      ${PERF_TEST_SYNC}
+    )
+  endforeach()
+
+  if(PERF_TEST_COMM_TYPE_${rmw_implementation})
+    foreach(PERF_TEST_SYNC "async" "sync")
+      add_performance_test(
+        ${PERF_TEST_COMM_TYPE_${rmw_implementation}}
+        ${PERF_TEST_COMM_TYPE_${rmw_implementation}}
+        ${rmw_implementation}
+        ${PERF_TEST_SYNC}
+      )
+    endforeach()
+  else()
+    message(STATUS "No standalone DDS support for RMW: ${rmw_implementation}")
+  endif()
+endmacro()

--- a/test/test_pub_sub.py.in
+++ b/test/test_pub_sub.py.in
@@ -67,7 +67,7 @@ def _raw_to_csv(dataframe, dataframe_perf, csv_path, mode):
 
     write_jenkins_plot_csv(
         '%s_%s.csv' % (csv_path[:-4], mode),
-        'Publisher-@TEST_NAME@_Subscriber-@COMM_SUB@', values)
+        'Publisher-@TEST_NAME@_Subscriber-@RMW_IMPLEMENTATION_SUB@', values)
 
 
 def _raw_to_png(dataframe, dataframe_perf, png_path, mode, rmw_impl):
@@ -77,28 +77,28 @@ def _raw_to_png(dataframe, dataframe_perf, png_path, mode, rmw_impl):
     plt.title('Simple Pub/Sub virtual memory usage\n' + mode + ': ' + rmw_impl)
     plt.ylim(0, 1024)
     plt.savefig(png_path + '_'
-                + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
+                + 'Publisher-@RMW_IMPLEMENTATION@_Subscriber-@RMW_IMPLEMENTATION_SUB@_'
                 + mode + '_virtual_memory.png')
 
     dataframe[['T_experiment', 'cpu_usage (%)']].plot(x='T_experiment')
     plt.title('Simple Pub/Sub CPU usage\n' + mode + ': ' + rmw_impl)
     plt.ylim(0, 100)
     plt.savefig(png_path + '_'
-                + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
+                + 'Publisher-@RMW_IMPLEMENTATION@_Subscriber-@RMW_IMPLEMENTATION_SUB@_'
                 + mode + '_cpu_usage.png')
 
     dataframe[['T_experiment', 'physical memory (Mb)']].plot(x='T_experiment')
     plt.title('Simple Pub/Sub physical memory usage\n' + mode + ': ' + rmw_impl)
     plt.ylim(0, 100)
     plt.savefig(png_path + '_'
-                + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
+                + 'Publisher-@RMW_IMPLEMENTATION@_Subscriber-@RMW_IMPLEMENTATION_SUB@_'
                 + mode + '_physical_memory.png')
 
     dataframe[['T_experiment', 'resident anonymous memory (Mb)']].plot(x='T_experiment')
     plt.title('Simple Pub/Sub resident anonymous memory\n' + mode + ': ' + rmw_impl)
     plt.ylim(0, 100)
     plt.savefig(png_path + '_'
-                + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
+                + 'Publisher-@RMW_IMPLEMENTATION@_Subscriber-@RMW_IMPLEMENTATION_SUB@_'
                 + mode + '_resident_anonymous_memory.png')
 
     if mode == 'subscriber':
@@ -109,7 +109,7 @@ def _raw_to_png(dataframe, dataframe_perf, png_path, mode, rmw_impl):
     dataframe.plot(kind='bar', y=['received', 'sent', 'lost'])
     plt.title('Simple Pub/Sub Received/Sent/Lost packets\n' + mode + ': ' + rmw_impl)
     plt.savefig(png_path + '_'
-                + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
+                + 'Publisher-@RMW_IMPLEMENTATION@_Subscriber-@RMW_IMPLEMENTATION_SUB@_'
                 + mode + '_histogram.png')
 
     dataframe['maxrss (Mb)'] = dataframe['ru_maxrss'] / 1e3
@@ -121,10 +121,10 @@ def _raw_to_png(dataframe, dataframe_perf, png_path, mode, rmw_impl):
                'latency_mean (ms)',
                'latency_variance (ms) * 100',
                'maxrss (Mb)']].plot(x='T_experiment', secondary_y=['maxrss (Mb)'])
-    plt.title('Simple Pub/Sub latency\n' + mode + ': ' + '@COMM_PUB@'
-              + '\nsubscriber: ' + '@COMM_SUB@')
+    plt.title('Simple Pub/Sub latency\n' + mode + ': ' + '@RMW_IMPLEMENTATION@'
+              + '\nsubscriber: ' + '@RMW_IMPLEMENTATION_SUB@')
     plt.savefig(png_path + '_'
-                + 'Publisher-@COMM_PUB@_Subscriber-@COMM_SUB@_'
+                + 'Publisher-@RMW_IMPLEMENTATION@_Subscriber-@RMW_IMPLEMENTATION_SUB@_'
                 + mode + '_latency.png')
 
 
@@ -157,7 +157,6 @@ def generate_test_description(ready_fn):
             '--roundtrip_mode', 'Main',
             '--ignore', '3',
         ],
-        additional_env={'RMW_IMPLEMENTATION': '@COMM_PUB@'},
     )
 
     system_metric_collector_pub, node_main_test_hook = attach_system_metric_collector(
@@ -174,7 +173,7 @@ def generate_test_description(ready_fn):
             '--roundtrip_mode', 'Relay',
             '--ignore', '3',
         ],
-        additional_env={'RMW_IMPLEMENTATION': '@COMM_SUB@'},
+        additional_env={'RMW_IMPLEMENTATION': '@RMW_IMPLEMENTATION_SUB@'},
     )
 
     system_metric_collector_sub, node_relay_test_hook = attach_system_metric_collector(
@@ -247,7 +246,7 @@ class PerformanceTestResults(unittest.TestCase):
             performance_report_png = os.environ.get('PERFORMANCE_OVERHEAD_PNG')
             if performance_report_png:
                 _raw_to_png(performance_log_data, performance_log_perf_data,
-                            performance_report_png, 'publisher', '@COMM_PUB@')
+                            performance_report_png, 'publisher', '@RMW_IMPLEMENTATION@')
             else:
                 print('No PNG report written - set PERFORMANCE_OVERHEAD_PNG to write a report',
                       file=sys.stderr)
@@ -273,7 +272,7 @@ class PerformanceTestResults(unittest.TestCase):
             performance_report_png = os.environ.get('PERFORMANCE_OVERHEAD_PNG')
             if performance_report_png:
                 _raw_to_png(performance_log_data, performance_log_perf_data,
-                            performance_report_png, 'subscriber', '@COMM_SUB@')
+                            performance_report_png, 'subscriber', '@RMW_IMPLEMENTATION_SUB@')
             else:
                 print('No PNG report written - set PERFORMANCE_OVERHEAD_PNG to write a report',
                       file=sys.stderr)


### PR DESCRIPTION
Under the new model, no special cases or exclusions should ever be added to `add_performance_tests.cmake`. Rather, the configuration of per-RMW or per-DDS behaviors should be configured directly in test/CMakeLists.txt using a generic mechanism.

This PR doesn't actually change any of the default behavior, the same set of tests is run for a default build. It centralizes the "configuration" of the test run from the execution, and allows specification of more of the parameters using CMake variables to enable testing without modifying the code.

Without this change: http://build.ros2.org/job/Fci__overlay_ubuntu_focal_amd64/24/testReport/buildfarm_perf_tests/
With this change: http://build.ros2.org/job/Fci__overlay_ubuntu_focal_amd64/25/testReport/buildfarm_perf_tests/

Related to #18