### PR TITLE
Improve error handling in system_metric_collector

### DIFF
--- a/src/linux_cpu_process_measurement.cpp
+++ b/src/linux_cpu_process_measurement.cpp
@@ -121,6 +121,10 @@ double LinuxCPUProcessMeasurement::getCPUCurrentlyUsedByCurrentProcess()
 
   std::ifstream inputFile(std::string("/proc/") + this->pid_ + std::string("/stat"));
 
+  if (!inputFile.good()) {
+    return 0;
+  }
+
   inputFile >> pid >> tcomm_string >> state >> ppid >> pgid >> sid >> tty_nr >>
   tty_pgrp >> flags >> min_flt >> cmin_flt >> maj_flt >> cmaj_flt >>
   utime >> stimev >> cutime >> cstime >> priority >> nicev >> num_threads >>

--- a/src/linux_cpu_system_measurement.cpp
+++ b/src/linux_cpu_system_measurement.cpp
@@ -75,7 +75,9 @@ float LinuxCPUSystemMeasurement::getCPUSystemCurrentlyUsed()
     const float IDLE_TIME = static_cast<float>(GetIdleTime(e2) - GetIdleTime(e1));
     const float TOTAL_TIME = ACTIVE_TIME + IDLE_TIME;
 
-    total += (100.f * ACTIVE_TIME / TOTAL_TIME);
+    if (TOTAL_TIME > 0.0) {
+      total += (100.f * ACTIVE_TIME / TOTAL_TIME);
+    }
   }
 
   entries1_ = entries2_;
@@ -92,25 +94,26 @@ void LinuxCPUSystemMeasurement::ReadStatsCPU(std::vector<CPUData> & entries)
 
   const std::string STR_CPU("cpu");
   const std::size_t LEN_STR_CPU = STR_CPU.size();
-  const std::string STR_TOT("tot");
 
   while (std::getline(fileStat, line)) {
     // cpu stats line found
     if (!line.compare(0, LEN_STR_CPU, STR_CPU)) {
       std::istringstream ss(line);
 
+      // read cpu label
+      std::string label;
+      ss >> label;
+
+      if (label.size() > LEN_STR_CPU) {
+        label.erase(0, LEN_STR_CPU);
+      } else {
+        continue;
+      }
+
       // store entry
       entries.emplace_back(CPUData());
       CPUData & entry = entries.back();
-
-      // read cpu label
-      ss >> entry.cpu;
-
-      if (entry.cpu.size() > LEN_STR_CPU) {
-        entry.cpu.erase(0, LEN_STR_CPU);
-      } else {
-        entry.cpu = STR_TOT;
-      }
+      entry.cpu = label;
 
       // read times
       for (int i = 0; i < NUM_CPU_STATES; ++i) {

--- a/src/linux_memory_process_measurement.cpp
+++ b/src/linux_memory_process_measurement.cpp
@@ -30,6 +30,9 @@ LinuxMemoryProcessMeasurement::LinuxMemoryProcessMeasurement(std::string pid)
 int LinuxMemoryProcessMeasurement::getVirtualMemoryCurrentlyUsedByCurrentProcess()
 {  // Note: this value is in KB!
   std::ifstream inputFile(std::string("/proc/") + this->pid_ + std::string("/statm"));
+  if (!inputFile.good()) {
+    return 0;
+  }
   int process_memory_used;
   int process_memory_used_resident;
   inputFile >> process_memory_used >> process_memory_used_resident;
@@ -39,6 +42,9 @@ int LinuxMemoryProcessMeasurement::getVirtualMemoryCurrentlyUsedByCurrentProcess
 int LinuxMemoryProcessMeasurement::getResidentAnonymousMemoryCurrentlyUsedByCurrentProcess()
 {  // Note: this value is in KB!
   std::ifstream inputFile(std::string("/proc/") + this->pid_ + std::string("/statm"));
+  if (!inputFile.good()) {
+    return 0;
+  }
   int process_memory_used;
   int process_memory_used_resident;
   inputFile >> process_memory_used >> process_memory_used_resident;
@@ -58,7 +64,7 @@ int LinuxMemoryProcessMeasurement::getPhysicalMemoryCurrentlyUsedByCurrentProces
       }
     }
   }
-  return -1;
+  return 0;
 }
 
 void LinuxMemoryProcessMeasurement::makeReading()


### PR DESCRIPTION
A few errors here:
1. Actually check the the files were opened to avoid getting garbage readings. You'll see a '0' in the results if the process wasn't running for that reading, which isn't entirely wrong.
2. Don't include 'Total CPU usage' column when enumerating the cumulative CPU usage. The calculation was treating this data as an "extra CPU" which throws off the calculations.
3. Handle case where a CPU does no work between measurements (avoid divide by zero).