### PR TITLE
Unify runtime parameter

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Global performance test settings
 #
 
-set(PERF_TEST_MAX_RUNTIME 30
+set(PERF_TEST_RUNTIME 30
   CACHE STRING "Duration for each performance test run")
 set(PERF_TEST_TOPIC_PUB_SUB Array60k
   CACHE STRING "perf_test topic used by pub/stub tests")

--- a/test/add_performance_tests.cmake
+++ b/test/add_performance_tests.cmake
@@ -55,6 +55,9 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
   endif()
   list(APPEND TEST_ENV ${PERF_TEST_ENV_${TEST_NAME_SYNC}})
 
+  # Have CTest kill the test if it runs for more than 3x what it should
+  math(EXPR PERF_TEST_TIMEOUT "${PERF_TEST_RUNTIME} * 3")
+
   #
   # Setup for per-topic tests
   #
@@ -99,6 +102,7 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
       "${CMAKE_CURRENT_BINARY_DIR}/test/test_performance_${TEST_NAME_SYNC_TOPIC}.py"
       TARGET test_performance_${TEST_NAME_SYNC_TOPIC}
       ENV ${TEST_ENV_TOPIC}
+      TIMEOUT ${PERF_TEST_TIMEOUT}
       ${SKIP_TEST_TOPIC}
     )
     set_tests_properties(test_performance_${TEST_NAME_SYNC_TOPIC} PROPERTIES
@@ -147,6 +151,7 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
       "${CMAKE_CURRENT_BINARY_DIR}/test/test_performance_two_process_${TEST_NAME_SYNC_TOPIC}.py"
       TARGET test_performance_two_process_${TEST_NAME_SYNC_TOPIC}
       ENV ${TEST_ENV_TOPIC}
+      TIMEOUT ${PERF_TEST_TIMEOUT}
       ${SKIP_TEST_TOPIC}
     )
     set_tests_properties(
@@ -192,8 +197,6 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
   set(TEST_ENV_SPINNING ${TEST_ENV})
   list(APPEND TEST_ENV_SPINNING ${PERF_TEST_ENV_spinning_${TEST_NAME_SYNC}})
 
-  set(NODE_SPINNING_TIMEOUT "30")
-
   get_filename_component(
     PERF_TEST_RESULTS_BASE_PATH
     "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/overhead_node_test_results_${TEST_NAME_SYNC}"
@@ -219,7 +222,7 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
     "${CMAKE_CURRENT_BINARY_DIR}/test/test_spinning_${TEST_NAME_SYNC}.py"
     TARGET test_spinning_${TEST_NAME_SYNC}
     ENV ${TEST_ENV_SPINNING}
-    TIMEOUT 120
+    TIMEOUT ${PERF_TEST_TIMEOUT}
     ${SKIP_TEST_SPINNING}
   )
   set_tests_properties(test_spinning_${TEST_NAME_SYNC} PROPERTIES
@@ -231,7 +234,6 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
   # Setup for cross-vendor tests
   #
 
-  set(PUBSUB_TIMEOUT "30")
   set(PERF_TEST_TOPIC ${PERF_TEST_TOPIC_PUB_SUB})
   get_available_rmw_implementations(_rmw_implementations)
   foreach(RMW_IMPLEMENTATION_SUB ${_rmw_implementations})
@@ -284,7 +286,7 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
       "${CMAKE_CURRENT_BINARY_DIR}/test/test_pub_sub_${TEST_NAME_PUB_SUB}.py"
       TARGET test_pub_sub_${TEST_NAME_PUB_SUB}
       ENV ${TEST_ENV_PUB_SUB}
-      TIMEOUT 120
+      TIMEOUT ${PERF_TEST_TIMEOUT}
       ${SKIP_TEST_PUB_SUB}
     )
     set_tests_properties(test_pub_sub_${TEST_NAME_PUB_SUB} PROPERTIES

--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -123,7 +123,7 @@ def generate_test_description(ready_fn):
     args = [
         '-c', '@COMM@',
         '-t', '@PERF_TEST_TOPIC@',
-        '--max_runtime', '@PERF_TEST_MAX_RUNTIME@',
+        '--max_runtime', '@PERF_TEST_RUNTIME@',
         '--ignore', '3',
         '-l', performance_log_prefix,
     ]
@@ -143,7 +143,7 @@ def generate_test_description(ready_fn):
           arguments=[
               '-c', '@COMM@',
               '-t', '@PERF_TEST_TOPIC@',
-              '--max_runtime', '@PERF_TEST_MAX_RUNTIME@',
+              '--max_runtime', '@PERF_TEST_RUNTIME@',
               '--roundtrip_mode', 'Relay',
           ],
         )
@@ -169,7 +169,7 @@ class PerformanceTestTermination(unittest.TestCase):
         for node in nodes:
             proc_info.assertWaitForShutdown(
                 process=node,
-                timeout=(@PERF_TEST_MAX_RUNTIME@ * 2))
+                timeout=(@PERF_TEST_RUNTIME@ * 2))
 
 
 @launch_testing.post_shutdown_test()

--- a/test/test_pub_sub.py.in
+++ b/test/test_pub_sub.py.in
@@ -151,7 +151,7 @@ def generate_test_description(ready_fn):
         arguments=[
             '-c', 'ROS2',
             '-t', '@PERF_TEST_TOPIC@',
-            '--max_runtime', '@PUBSUB_TIMEOUT@',
+            '--max_runtime', '@PERF_TEST_RUNTIME@',
             '-l', performance_log_prefix_pub,
             '--rate', '5',
             '--roundtrip_mode', 'Main',
@@ -160,14 +160,14 @@ def generate_test_description(ready_fn):
     )
 
     system_metric_collector_pub, node_main_test_hook = attach_system_metric_collector(
-        node_main_test, performance_log_prefix_cpumem_pub, timeout=@PUBSUB_TIMEOUT@)
+        node_main_test, performance_log_prefix_cpumem_pub, timeout=@PERF_TEST_RUNTIME@)
 
     node_relay_test = Node(
         package='performance_test', node_executable='perf_test', output='log',
         arguments=[
             '-c', 'ROS2',
             '-t', '@PERF_TEST_TOPIC@',
-            '--max_runtime', '@PUBSUB_TIMEOUT@',
+            '--max_runtime', '@PERF_TEST_RUNTIME@',
             '-l', performance_log_prefix_sub,
             '--rate', '5',
             '--roundtrip_mode', 'Relay',
@@ -177,7 +177,7 @@ def generate_test_description(ready_fn):
     )
 
     system_metric_collector_sub, node_relay_test_hook = attach_system_metric_collector(
-        node_relay_test, performance_log_prefix_cpumem_sub, timeout=@PUBSUB_TIMEOUT@)
+        node_relay_test, performance_log_prefix_cpumem_sub, timeout=@PERF_TEST_RUNTIME@)
 
     return LaunchDescription([
         node_main_test_hook,
@@ -195,11 +195,11 @@ class PerformanceTestTermination(unittest.TestCase):
             self, system_metric_collector_sub, system_metric_collector_pub,
             node_main_test, node_relay_test, proc_info):
         proc_info.assertWaitForShutdown(process=system_metric_collector_sub,
-                                        timeout=(@PUBSUB_TIMEOUT@ * 2))
+                                        timeout=(@PERF_TEST_RUNTIME@ * 2))
         proc_info.assertWaitForShutdown(process=system_metric_collector_pub,
-                                        timeout=(@PUBSUB_TIMEOUT@ * 2))
-        proc_info.assertWaitForShutdown(process=node_main_test, timeout=(@PUBSUB_TIMEOUT@ * 2))
-        proc_info.assertWaitForShutdown(process=node_relay_test, timeout=(@PUBSUB_TIMEOUT@ * 2))
+                                        timeout=(@PERF_TEST_RUNTIME@ * 2))
+        proc_info.assertWaitForShutdown(process=node_main_test, timeout=(@PERF_TEST_RUNTIME@ * 2))
+        proc_info.assertWaitForShutdown(process=node_relay_test, timeout=(@PERF_TEST_RUNTIME@ * 2))
 
 
 @launch_testing.post_shutdown_test()

--- a/test/test_spinning.py.in
+++ b/test/test_spinning.py.in
@@ -11,8 +11,13 @@ from buildfarm_perf_tests.launch import attach_system_metric_collector
 from buildfarm_perf_tests.test_results import read_performance_test_csv
 from buildfarm_perf_tests.test_results import write_jenkins_plot_csv
 from launch import LaunchDescription
+from launch.actions import EmitEvent
 from launch.actions import OpaqueFunction
-from launch.substitutions import LaunchConfiguration
+from launch.actions import RegisterEventHandler
+from launch.actions import TimerAction
+from launch.event_handlers import OnProcessStart
+from launch.events import matches_action
+from launch.events.process import ShutdownProcess
 from launch_ros.actions import Node
 import launch_testing
 import matplotlib  # noqa: F401
@@ -92,15 +97,22 @@ def generate_test_description(ready_fn):
         package='buildfarm_perf_tests',
         node_executable='node_spinning',
         output='log',
-        sigterm_timeout=LaunchConfiguration('sigterm_timeout', default=@NODE_SPINNING_TIMEOUT@+2)
     )
+    node_spinning_timer = RegisterEventHandler(OnProcessStart(
+        target_action=node_spinning_test, on_start=TimerAction(
+            period=float(@PERF_TEST_RUNTIME@), actions=[
+                EmitEvent(
+                    event=ShutdownProcess(
+                        process_matcher=matches_action(node_spinning_test)))
+                ])))
 
     node_metrics_collector, node_spinning_test_hook = attach_system_metric_collector(
-        node_spinning_test, performance_log_prefix_cpumem, timeout=@NODE_SPINNING_TIMEOUT@)
+        node_spinning_test, performance_log_prefix_cpumem, timeout=@PERF_TEST_RUNTIME@)
 
     return LaunchDescription([
         node_spinning_test_hook,
         node_spinning_test,
+        node_spinning_timer,
         launch_testing.util.KeepAliveProc(),
         OpaqueFunction(function=lambda context: ready_fn()),
     ]), locals()
@@ -108,9 +120,12 @@ def generate_test_description(ready_fn):
 
 class NodeSpinningTestTermination(unittest.TestCase):
 
-    def test_termination_@TEST_NAME@(self, node_metrics_collector, proc_info):
+    def test_termination_@TEST_NAME@(
+            self, node_spinning_test, node_metrics_collector, proc_info):
+        proc_info.assertWaitForShutdown(process=node_spinning_test,
+                                        timeout=(@PERF_TEST_RUNTIME@ * 2))
         proc_info.assertWaitForShutdown(process=node_metrics_collector,
-                                        timeout=(@NODE_SPINNING_TIMEOUT@ * 2))
+                                        timeout=(@PERF_TEST_RUNTIME@ * 2))
 
 
 @launch_testing.post_shutdown_test()


### PR DESCRIPTION
Use the same parameter, `PERF_TEST_RUNTIME`, to configure how long each of the tests should be run.

Additionally, configure Launch to terminate any of the processes that run for twice that duration, and if that fails, configure CTest to kill everything after three times that duration.

Part of this change also involved setting up a proper trigger to terminate the spinning process instead of relying on test completion to trigger the shutdown.