### PR TITLE
Use a single path to write test results to

### DIFF
--- a/test/add_performance_tests.cmake
+++ b/test/add_performance_tests.cmake
@@ -76,18 +76,12 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
     set(NUMBER_PROCESS "1")
 
     get_filename_component(
-      PERFORMANCE_REPORT_PNG
-      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/performance_test_results_${TEST_NAME_SYNC_TOPIC}.png"
-      ABSOLUTE
-    )
-    get_filename_component(
-      PERFORMANCE_REPORT_CSV
-      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/performance_test_results_${TEST_NAME_SYNC_TOPIC}.csv"
+      PERF_TEST_RESULTS_BASE_PATH
+      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/performance_test_results_${TEST_NAME_SYNC_TOPIC}"
       ABSOLUTE
     )
     list(APPEND TEST_ENV_TOPIC
-      "PERFORMANCE_REPORT_PNG=${PERFORMANCE_REPORT_PNG}"
-      "PERFORMANCE_REPORT_CSV=${PERFORMANCE_REPORT_CSV}"
+      "PERF_TEST_RESULTS_BASE_PATH=${PERF_TEST_RESULTS_BASE_PATH}"
     )
 
     configure_file(
@@ -129,18 +123,12 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
     set(NUMBER_PROCESS "2")
 
     get_filename_component(
-      PERFORMANCE_REPORT_PNG
-      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/performance_test_two_process_results_${TEST_NAME_SYNC_TOPIC}.png"
-      ABSOLUTE
-    )
-    get_filename_component(
-      PERFORMANCE_REPORT_CSV
-      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/performance_test_two_process_results_${TEST_NAME_SYNC_TOPIC}.csv"
+      PERF_TEST_RESULTS_BASE_PATH
+      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/performance_test_two_process_results_${TEST_NAME_SYNC_TOPIC}"
       ABSOLUTE
     )
     list(APPEND TEST_ENV_TOPIC
-      "PERFORMANCE_REPORT_PNG=${PERFORMANCE_REPORT_PNG}"
-      "PERFORMANCE_REPORT_CSV=${PERFORMANCE_REPORT_CSV}"
+      "PERF_TEST_RESULTS_BASE_PATH=${PERF_TEST_RESULTS_BASE_PATH}"
     )
 
     configure_file(
@@ -207,18 +195,12 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
   set(NODE_SPINNING_TIMEOUT "30")
 
   get_filename_component(
-    PERFORMANCE_OVERHEAD_NODE_CSV
-    "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/overhead_node_test_results_${TEST_NAME_SYNC}.csv"
-    ABSOLUTE
-  )
-  get_filename_component(
-    PERFORMANCE_OVERHEAD_NODE_PNG
-    "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/overhead_node_test_results_${TEST_NAME_SYNC}.png"
+    PERF_TEST_RESULTS_BASE_PATH
+    "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/overhead_node_test_results_${TEST_NAME_SYNC}"
     ABSOLUTE
   )
   list(APPEND TEST_ENV_SPINNING
-    "PERFORMANCE_OVERHEAD_NODE_CSV=${PERFORMANCE_OVERHEAD_NODE_CSV}"
-    "PERFORMANCE_OVERHEAD_NODE_PNG=${PERFORMANCE_OVERHEAD_NODE_PNG}"
+    "PERF_TEST_RESULTS_BASE_PATH=${PERF_TEST_RESULTS_BASE_PATH}"
   )
 
   configure_file(
@@ -270,8 +252,8 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
     list(APPEND TEST_ENV_PUB_SUB ${PERF_TEST_ENV_${TEST_NAME_PUB_SUB}})
 
     get_filename_component(
-      PERFORMANCE_OVERHEAD_CSV
-      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/overhead_test_results_${TEST_NAME_PUB_SUB}.csv"
+      PERF_TEST_RESULTS_BASE_PATH
+      "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/overhead_test_results_${TEST_NAME_PUB_SUB}"
       ABSOLUTE
     )
     # TODO: Why doesn't this file name have a suffix?
@@ -280,8 +262,9 @@ function(add_performance_test TEST_NAME COMM RMW_IMPLEMENTATION SYNC_MODE)
       "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/overhead_test_results"
       ABSOLUTE
     )
+
     list(APPEND TEST_ENV_PUB_SUB
-      "PERFORMANCE_OVERHEAD_CSV=${PERFORMANCE_OVERHEAD_CSV}"
+      "PERF_TEST_RESULTS_BASE_PATH=${PERF_TEST_RESULTS_BASE_PATH}"
       "PERFORMANCE_OVERHEAD_PNG=${PERFORMANCE_OVERHEAD_PNG}"
     )
 

--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -186,23 +186,18 @@ class PerformanceTestResults(unittest.TestCase):
                 node,
             )
 
-        performance_logs = glob(performance_log_prefix + '_*')
-
-        if performance_logs:
-            performance_log_data = read_performance_test_csv(performance_logs[0])
-
-            performance_report_csv = os.environ.get('PERFORMANCE_REPORT_CSV')
-            if performance_report_csv:
-                _raw_to_csv(performance_log_data, performance_report_csv)
+        results_base_path = os.environ.get('PERF_TEST_RESULTS_BASE_PATH')
+        if results_base_path:
+            performance_logs = glob(performance_log_prefix + '*')
+            if performance_logs:
+                performance_data = read_performance_test_csv(performance_logs[0])
+                _raw_to_csv(performance_data, results_base_path + '.csv')
+                _raw_to_png(performance_data, results_base_path + '.png')
             else:
-                print('No CSV report written - set PERFORMANCE_REPORT_CSV to write a report',
-                      file=sys.stderr)
-
-            performance_report_png = os.environ.get('PERFORMANCE_REPORT_PNG')
-            if performance_report_png:
-                _raw_to_png(performance_log_data, performance_report_png)
-            else:
-                print('No PNG report written - set PERFORMANCE_REPORT_PNG to write a report',
-                      file=sys.stderr)
+                print(
+                    'No report written - no performance log was produced',
+                    file=sys.stderr)
         else:
-            print('No report written - no performance log was produced', file=sys.stderr)
+            print(
+                'No results reports written - set PERF_TEST_RESULTS_BASE_PATH to write reports',
+                file=sys.stderr)

--- a/test/test_pub_sub.py.in
+++ b/test/test_pub_sub.py.in
@@ -227,54 +227,45 @@ class PerformanceTestResults(unittest.TestCase):
             node_main_test,
         )
 
-        performance_logs = glob(performance_log_prefix_cpumem_pub + '*')
-        performance_logs_perf_test = glob(performance_log_prefix_pub + '_*')
-
-        if performance_logs and performance_logs_perf_test:
-            performance_log_data = read_performance_test_csv(
-                performance_logs[0], start_marker=None)
-            performance_log_perf_data = read_performance_test_csv(performance_logs_perf_test[0])
-
-            performance_report_csv = os.environ.get('PERFORMANCE_OVERHEAD_CSV')
-            if performance_report_csv:
-                _raw_to_csv(performance_log_data, performance_log_perf_data,
-                            performance_report_csv, 'pub')
+        results_base_path = os.environ.get('PERF_TEST_RESULTS_BASE_PATH')
+        performance_overhead_png = os.environ.get('PERFORMANCE_OVERHEAD_PNG')
+        if results_base_path:
+            performance_logs = glob(performance_log_prefix_pub + '*')
+            performance_logs_cpumem = glob(performance_log_prefix_cpumem_pub + '*')
+            if performance_logs and performance_logs_cpumem:
+                performance_data = read_performance_test_csv(performance_logs[0])
+                performance_data_cpumem = read_performance_test_csv(
+                    performance_logs_cpumem[0], start_marker=None)
+                _raw_to_csv(
+                    performance_data_cpumem, performance_data,
+                    results_base_path + '.csv', 'pub')
+                if performance_overhead_png:
+                    _raw_to_png(
+                        performance_data_cpumem, performance_data,
+                        performance_overhead_png, 'publisher', '@RMW_IMPLEMENTATION@')
             else:
-                print('No CSV report written - set PERFORMANCE_OVERHEAD_CSV to write a report',
-                      file=sys.stderr)
+                print(
+                    'No report written - no performance log was produced',
+                    file=sys.stderr)
 
-            performance_report_png = os.environ.get('PERFORMANCE_OVERHEAD_PNG')
-            if performance_report_png:
-                _raw_to_png(performance_log_data, performance_log_perf_data,
-                            performance_report_png, 'publisher', '@RMW_IMPLEMENTATION@')
+            performance_logs = glob(performance_log_prefix_sub + '*')
+            performance_logs_cpumem = glob(performance_log_prefix_cpumem_sub + '*')
+            if performance_logs and performance_logs_cpumem:
+                performance_data = read_performance_test_csv(performance_logs[0])
+                performance_data_cpumem = read_performance_test_csv(
+                    performance_logs_cpumem[0], start_marker=None)
+                _raw_to_csv(
+                    performance_data_cpumem, performance_data,
+                    results_base_path + '.csv', 'sub')
+                if performance_overhead_png:
+                    _raw_to_png(
+                        performance_data_cpumem, performance_data,
+                        performance_overhead_png, 'subscriber', '@RMW_IMPLEMENTATION_SUB@')
             else:
-                print('No PNG report written - set PERFORMANCE_OVERHEAD_PNG to write a report',
-                      file=sys.stderr)
+                print(
+                    'No report written - no performance log was produced',
+                    file=sys.stderr)
         else:
-            print('No report written - no performance log was produced', file=sys.stderr)
-
-        performance_logs = glob(performance_log_prefix_cpumem_sub + '*')
-        performance_logs_perf_test = glob(performance_log_prefix_sub + '_*')
-
-        if performance_logs and performance_logs_perf_test:
-            performance_log_data = read_performance_test_csv(
-                performance_logs[0], start_marker=None)
-            performance_log_perf_data = read_performance_test_csv(performance_logs_perf_test[0])
-
-            performance_report_csv = os.environ.get('PERFORMANCE_OVERHEAD_CSV')
-            if performance_report_csv:
-                _raw_to_csv(performance_log_data, performance_log_perf_data,
-                            performance_report_csv, 'sub')
-            else:
-                print('No CSV report written - set PERFORMANCE_OVERHEAD_CSV to write a report',
-                      file=sys.stderr)
-
-            performance_report_png = os.environ.get('PERFORMANCE_OVERHEAD_PNG')
-            if performance_report_png:
-                _raw_to_png(performance_log_data, performance_log_perf_data,
-                            performance_report_png, 'subscriber', '@RMW_IMPLEMENTATION_SUB@')
-            else:
-                print('No PNG report written - set PERFORMANCE_OVERHEAD_PNG to write a report',
-                      file=sys.stderr)
-        else:
-            print('No report written - no performance log was produced', file=sys.stderr)
+            print(
+                'No results reports written - set PERF_TEST_RESULTS_BASE_PATH to write reports',
+                file=sys.stderr)

--- a/test/test_spinning.py.in
+++ b/test/test_spinning.py.in
@@ -60,31 +60,32 @@ def _raw_to_csv(dataframe, csv_path):
 
 
 def _raw_to_png(dataframe, png_path):
+    png_base, png_ext = os.path.splitext(png_path)
     pd.options.display.float_format = '{:.4f}'.format
     dataframe[['T_experiment', 'virtual memory (Mb)']].plot(x='T_experiment')
 
     plt.title('Node spinning virtual memory usage\n@TEST_NAME@')
     plt.ylim(0, 1024)
-    plt.savefig(png_path[:-4] + '_virtual_memory.png')
+    plt.savefig(png_base + '_virtual_memory' + png_ext)
 
     dataframe[['T_experiment', 'cpu_usage (%)']].plot(x='T_experiment')
     plt.title('Node spinning CPU usage\n@TEST_NAME@')
     plt.ylim(0, 100)
-    plt.savefig(png_path[:-4] + '_cpu_usage.png')
+    plt.savefig(png_base + '_cpu_usage' + png_ext)
 
     dataframe[['T_experiment', 'physical memory (Mb)']].plot(x='T_experiment')
     plt.ylim(0, 100)
     plt.title('Node spinning physical memory usage\n@TEST_NAME@')
-    plt.savefig(png_path[:-4] + '_physical_memory.png')
+    plt.savefig(png_base + '_physical_memory' + png_ext)
 
     dataframe[['T_experiment', 'resident anonymous memory (Mb)']].plot(x='T_experiment')
     plt.title('Node spinning resident anonymous memory\n@TEST_NAME@')
     plt.ylim(0, 100)
-    plt.savefig(png_path[:-4] + '_resident_anonymous_memory.png')
+    plt.savefig(png_base + '_resident_anonymous_memory' + png_ext)
 
 
 def generate_test_description(ready_fn):
-    node_spinning_log_prefix = tempfile.mkstemp(
+    performance_log_prefix_cpumem = tempfile.mkstemp(
         prefix='overhead_node_test_results_@TEST_NAME@_', text=True)[1]
 
     node_spinning_test = Node(
@@ -95,7 +96,7 @@ def generate_test_description(ready_fn):
     )
 
     node_metrics_collector, node_spinning_test_hook = attach_system_metric_collector(
-        node_spinning_test, node_spinning_log_prefix, timeout=@NODE_SPINNING_TIMEOUT@)
+        node_spinning_test, performance_log_prefix_cpumem, timeout=@NODE_SPINNING_TIMEOUT@)
 
     return LaunchDescription([
         node_spinning_test_hook,
@@ -116,9 +117,9 @@ class NodeSpinningTestTermination(unittest.TestCase):
 class NodeSpinningTestResults(unittest.TestCase):
 
     def test_results_@TEST_NAME@(
-            self, node_spinning_log_prefix,
+            self, performance_log_prefix_cpumem,
             node_metrics_collector, proc_info):
-        self.addCleanup(_cleanUpLogs, node_spinning_log_prefix)
+        self.addCleanup(_cleanUpLogs, performance_log_prefix_cpumem)
 
         launch_testing.asserts.assertExitCodes(
             proc_info,
@@ -126,27 +127,19 @@ class NodeSpinningTestResults(unittest.TestCase):
             node_metrics_collector,
         )
 
-        node_spinning_logs = glob(node_spinning_log_prefix + '*')
-
-        if node_spinning_logs:
-            node_spinning_data = read_performance_test_csv(
-                node_spinning_logs[0], start_marker=None)
-
-            node_spinning_report_csv = os.environ.get('PERFORMANCE_OVERHEAD_NODE_CSV')
-            if node_spinning_report_csv:
-                _raw_to_csv(node_spinning_data, node_spinning_report_csv)
+        results_base_path = os.environ.get('PERF_TEST_RESULTS_BASE_PATH')
+        if results_base_path:
+            performance_logs_cpumem = glob(performance_log_prefix_cpumem + '*')
+            if performance_logs_cpumem:
+                performance_data_cpumem = read_performance_test_csv(
+                    performance_logs_cpumem[0], start_marker=None)
+                _raw_to_csv(performance_data_cpumem, results_base_path + '.csv')
+                _raw_to_png(performance_data_cpumem, results_base_path + '.png')
             else:
                 print(
-                    'No CSV report written - set PERFORMANCE_OVERHEAD_NODE_CSV to write a report',
-                    file=sys.stderr)
-
-            node_spinning_report_png = os.environ.get('PERFORMANCE_OVERHEAD_NODE_PNG')
-            if node_spinning_report_png:
-                _raw_to_png(node_spinning_data, node_spinning_report_png)
-            else:
-                print(
-                    'No PNG report written - set PERFORMANCE_OVERHEAD_NODE_PNG to write a report',
+                    'No report written - no performance log was produced',
                     file=sys.stderr)
         else:
-            print('No report written - no performance log was produced',
-                  file=sys.stderr)
+            print(
+                'No results reports written - set PERF_TEST_RESULTS_BASE_PATH to write reports',
+                file=sys.stderr)


### PR DESCRIPTION
Instead of individual paths for CSV and PNG results, use a single "base path" value: `PERF_TEST_RESULTS_BASE_PATH`.

The only exception is the prefix for the pub/sub PNG files. It will be a breaking change to fix those, so I'll do it in a follow-up PR.