### PR TITLE
Simplify and fix log detection and cleanup

### DIFF
--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -25,8 +25,8 @@ BYTE_TO_MBYTE = 1 / (1024*1024)
 BYTE_TO_KBYTE = 1 / (1024)
 
 
-def _cleanUpLogs(performance_log_prefix):
-    for log in glob(performance_log_prefix + '*'):
+def _cleanUpLogs(log_pattern):
+    for log in glob(log_pattern):
         os.remove(log)
 
 
@@ -119,6 +119,10 @@ def generate_test_description(ready_fn):
     performance_log_prefix = tempfile.mkstemp(
         prefix='performance_test_@TEST_NAME@_', text=True)[1]
 
+    # perf_test will create its own logs with this prefix
+    # we just need the prefix to be unique
+    os.remove(performance_log_prefix)
+
     launch_description = []
     args = [
         '-c', '@COMM@',
@@ -177,7 +181,7 @@ class PerformanceTestResults(unittest.TestCase):
 
     def test_results_@TEST_NAME@(
             self, performance_log_prefix, nodes, proc_info):
-        self.addCleanup(_cleanUpLogs, performance_log_prefix)
+        self.addCleanup(_cleanUpLogs, performance_log_prefix + '*')
 
         for node in nodes:
             launch_testing.asserts.assertExitCodes(
@@ -189,14 +193,10 @@ class PerformanceTestResults(unittest.TestCase):
         results_base_path = os.environ.get('PERF_TEST_RESULTS_BASE_PATH')
         if results_base_path:
             performance_logs = glob(performance_log_prefix + '*')
-            if performance_logs:
-                performance_data = read_performance_test_csv(performance_logs[0])
-                _raw_to_csv(performance_data, results_base_path + '.csv')
-                _raw_to_png(performance_data, results_base_path + '.png')
-            else:
-                print(
-                    'No report written - no performance log was produced',
-                    file=sys.stderr)
+            assert len(performance_logs) == 1
+            performance_data = read_performance_test_csv(performance_logs[0])
+            _raw_to_csv(performance_data, results_base_path + '.csv')
+            _raw_to_png(performance_data, results_base_path + '.png')
         else:
             print(
                 'No results reports written - set PERF_TEST_RESULTS_BASE_PATH to write reports',

--- a/test/test_pub_sub.py.in
+++ b/test/test_pub_sub.py.in
@@ -22,8 +22,8 @@ import pandas as pd
 plt.switch_backend('agg')
 
 
-def _cleanUpLogs(performance_log_prefix):
-    for log in glob(performance_log_prefix):
+def _cleanUpLogs(log_pattern):
+    for log in glob(log_pattern):
         os.remove(log)
 
 
@@ -129,14 +129,14 @@ def _raw_to_png(dataframe, dataframe_perf, png_path, mode, rmw_impl):
 
 
 def generate_test_description(ready_fn):
-    performance_log_prefix_cpumem_pub = tempfile.mkstemp(
+    performance_log_cpumem_pub = tempfile.mkstemp(
         prefix='overhead_cpumem_pub_test_results_'
                + '@TEST_NAME_PUB_SUB@_',
-        text=True)[1]
-    performance_log_prefix_cpumem_sub = tempfile.mkstemp(
+        suffix='.csv', text=True)[1]
+    performance_log_cpumem_sub = tempfile.mkstemp(
         prefix='overhead_cpumem_sub_test_results_'
                + '@TEST_NAME_PUB_SUB@_',
-        text=True)[1]
+        suffix='.csv', text=True)[1]
     performance_log_prefix_pub = tempfile.mkstemp(
         prefix='overhead_pub_test_results_'
                + '@TEST_NAME_PUB_SUB@_',
@@ -145,6 +145,11 @@ def generate_test_description(ready_fn):
         prefix='overhead_sub_test_results_'
                + '@TEST_NAME_PUB_SUB@_',
         text=True)[1]
+
+    # perf_test will create its own logs with this prefix
+    # we just need the prefix to be unique
+    os.remove(performance_log_prefix_pub)
+    os.remove(performance_log_prefix_sub)
 
     node_main_test = Node(
         package='performance_test', node_executable='perf_test', output='log',
@@ -161,7 +166,7 @@ def generate_test_description(ready_fn):
 
     system_metric_collector_pub = SystemMetricCollector(
         target_action=node_main_test,
-        log_file=performance_log_prefix_cpumem_pub,
+        log_file=performance_log_cpumem_pub,
         timeout=(@PERF_TEST_RUNTIME@ // (1 / 1.5)))
 
     node_relay_test = Node(
@@ -180,7 +185,7 @@ def generate_test_description(ready_fn):
 
     system_metric_collector_sub = SystemMetricCollector(
         target_action=node_relay_test,
-        log_file=performance_log_prefix_cpumem_sub,
+        log_file=performance_log_cpumem_sub,
         timeout=(@PERF_TEST_RUNTIME@ // (1 / 1.5)))
 
     return LaunchDescription([
@@ -211,13 +216,13 @@ class PerformanceTestResults(unittest.TestCase):
 
     def test_results_@TEST_NAME_PUB_SUB@(
             self,
-            performance_log_prefix_cpumem_pub, performance_log_prefix_cpumem_sub,
+            performance_log_cpumem_pub, performance_log_cpumem_sub,
             performance_log_prefix_pub, performance_log_prefix_sub,
             proc_info, node_relay_test, node_main_test):
-        self.addCleanup(_cleanUpLogs, performance_log_prefix_pub)
-        self.addCleanup(_cleanUpLogs, performance_log_prefix_sub)
-        self.addCleanup(_cleanUpLogs, performance_log_prefix_cpumem_pub)
-        self.addCleanup(_cleanUpLogs, performance_log_prefix_cpumem_sub)
+        self.addCleanup(_cleanUpLogs, performance_log_prefix_pub + '*')
+        self.addCleanup(_cleanUpLogs, performance_log_prefix_sub + '*')
+        self.addCleanup(_cleanUpLogs, performance_log_cpumem_pub)
+        self.addCleanup(_cleanUpLogs, performance_log_cpumem_sub)
 
         launch_testing.asserts.assertExitCodes(
             proc_info,
@@ -235,40 +240,30 @@ class PerformanceTestResults(unittest.TestCase):
         performance_overhead_png = os.environ.get('PERFORMANCE_OVERHEAD_PNG')
         if results_base_path:
             performance_logs = glob(performance_log_prefix_pub + '*')
-            performance_logs_cpumem = glob(performance_log_prefix_cpumem_pub + '*')
-            if performance_logs and performance_logs_cpumem:
-                performance_data = read_performance_test_csv(performance_logs[0])
-                performance_data_cpumem = read_performance_test_csv(
-                    performance_logs_cpumem[0], start_marker=None)
-                _raw_to_csv(
+            assert len(performance_logs) == 1
+            performance_data = read_performance_test_csv(performance_logs[0])
+            performance_data_cpumem = read_performance_test_csv(
+                performance_log_cpumem_pub, start_marker=None)
+            _raw_to_csv(
+                performance_data_cpumem, performance_data,
+                results_base_path + '.csv', 'pub')
+            if performance_overhead_png:
+                _raw_to_png(
                     performance_data_cpumem, performance_data,
-                    results_base_path + '.csv', 'pub')
-                if performance_overhead_png:
-                    _raw_to_png(
-                        performance_data_cpumem, performance_data,
-                        performance_overhead_png, 'publisher', '@RMW_IMPLEMENTATION@')
-            else:
-                print(
-                    'No report written - no performance log was produced',
-                    file=sys.stderr)
+                    performance_overhead_png, 'publisher', '@RMW_IMPLEMENTATION@')
 
             performance_logs = glob(performance_log_prefix_sub + '*')
-            performance_logs_cpumem = glob(performance_log_prefix_cpumem_sub + '*')
-            if performance_logs and performance_logs_cpumem:
-                performance_data = read_performance_test_csv(performance_logs[0])
-                performance_data_cpumem = read_performance_test_csv(
-                    performance_logs_cpumem[0], start_marker=None)
-                _raw_to_csv(
+            assert len(performance_logs) == 1
+            performance_data = read_performance_test_csv(performance_logs[0])
+            performance_data_cpumem = read_performance_test_csv(
+                performance_log_cpumem_sub, start_marker=None)
+            _raw_to_csv(
+                performance_data_cpumem, performance_data,
+                results_base_path + '.csv', 'sub')
+            if performance_overhead_png:
+                _raw_to_png(
                     performance_data_cpumem, performance_data,
-                    results_base_path + '.csv', 'sub')
-                if performance_overhead_png:
-                    _raw_to_png(
-                        performance_data_cpumem, performance_data,
-                        performance_overhead_png, 'subscriber', '@RMW_IMPLEMENTATION_SUB@')
-            else:
-                print(
-                    'No report written - no performance log was produced',
-                    file=sys.stderr)
+                    performance_overhead_png, 'subscriber', '@RMW_IMPLEMENTATION_SUB@')
         else:
             print(
                 'No results reports written - set PERF_TEST_RESULTS_BASE_PATH to write reports',

--- a/test/test_spinning.py.in
+++ b/test/test_spinning.py.in
@@ -28,8 +28,8 @@ import pandas as pd
 plt.switch_backend('agg')
 
 
-def _cleanUpLogs(node_spinning_log_prefix):
-    for log in glob(node_spinning_log_prefix + '*'):
+def _cleanUpLogs(log_pattern):
+    for log in glob(log_pattern):
         os.remove(log)
 
 
@@ -90,8 +90,9 @@ def _raw_to_png(dataframe, png_path):
 
 
 def generate_test_description(ready_fn):
-    performance_log_prefix_cpumem = tempfile.mkstemp(
-        prefix='overhead_node_test_results_@TEST_NAME@_', text=True)[1]
+    performance_log_cpumem = tempfile.mkstemp(
+        prefix='overhead_node_test_results_@TEST_NAME@_',
+        suffix='.csv', text=True)[1]
 
     node_spinning_test = Node(
         package='buildfarm_perf_tests',
@@ -108,7 +109,7 @@ def generate_test_description(ready_fn):
 
     node_metrics_collector = SystemMetricCollector(
         target_action=node_spinning_test,
-        log_file=performance_log_prefix_cpumem,
+        log_file=performance_log_cpumem,
         timeout=(@PERF_TEST_RUNTIME@ // (1 / 1.5)))
 
     return LaunchDescription([
@@ -134,9 +135,9 @@ class NodeSpinningTestTermination(unittest.TestCase):
 class NodeSpinningTestResults(unittest.TestCase):
 
     def test_results_@TEST_NAME@(
-            self, performance_log_prefix_cpumem,
+            self, performance_log_cpumem,
             node_metrics_collector, proc_info):
-        self.addCleanup(_cleanUpLogs, performance_log_prefix_cpumem)
+        self.addCleanup(_cleanUpLogs, performance_log_cpumem)
 
         launch_testing.asserts.assertExitCodes(
             proc_info,
@@ -146,16 +147,10 @@ class NodeSpinningTestResults(unittest.TestCase):
 
         results_base_path = os.environ.get('PERF_TEST_RESULTS_BASE_PATH')
         if results_base_path:
-            performance_logs_cpumem = glob(performance_log_prefix_cpumem + '*')
-            if performance_logs_cpumem:
-                performance_data_cpumem = read_performance_test_csv(
-                    performance_logs_cpumem[0], start_marker=None)
-                _raw_to_csv(performance_data_cpumem, results_base_path + '.csv')
-                _raw_to_png(performance_data_cpumem, results_base_path + '.png')
-            else:
-                print(
-                    'No report written - no performance log was produced',
-                    file=sys.stderr)
+            performance_data_cpumem = read_performance_test_csv(
+                performance_log_cpumem, start_marker=None)
+            _raw_to_csv(performance_data_cpumem, results_base_path + '.csv')
+            _raw_to_png(performance_data_cpumem, results_base_path + '.png')
         else:
             print(
                 'No results reports written - set PERF_TEST_RESULTS_BASE_PATH to write reports',


### PR DESCRIPTION
There were some regression caused by 95d1780 which resulted in an attempt to process an empty file instead of the perf_test log. It did not occur deterministically, and some systems produced the issue and others did not. That is resolved by this change.

Additionally, some logs were not getting cleaned up, and the logic around the system_metric_collector logs was simplified.

The tests now fail if results were requested but the tools wrote no results files.

Should resolve last night's performance test regressions: http://build.ros2.org/view/Fci/job/Fci__nightly-performance_ubuntu_focal_amd64/42/testReport/