### PR TITLE
Support launch substitutions in SystemMetricCollector

### DIFF
--- a/buildfarm_perf_tests/launch.py
+++ b/buildfarm_perf_tests/launch.py
@@ -38,9 +38,9 @@ class SystemMetricCollector(Node):
         ----------
         target_action : ExecuteProcess
             ExecuteProcess (or Node) instance to collect metrics on
-        log_file : str
+        log_file : str or LaunchSubstitutionsType
             Path to where the collected metrics should be written to
-        timeout : int
+        timeout : int or LaunchSubstitutionsType
             Maximum time to run the metrics collector if the target process does
             not exit
 
@@ -60,7 +60,10 @@ class SystemMetricCollector(Node):
             '--log', log_file,
             '--process_pid', LocalSubstitution(self.__pid_var_name)]
         if timeout is not None:
-            kwargs['arguments'] += ['--timeout', str(timeout)]
+            kwargs['arguments'] += [
+                '--timeout',
+                str(timeout) if isinstance(timeout, int) else timeout
+            ]
 
         super().__init__(**kwargs)
 

--- a/test/test_pub_sub.py.in
+++ b/test/test_pub_sub.py.in
@@ -162,7 +162,7 @@ def generate_test_description(ready_fn):
     system_metric_collector_pub = SystemMetricCollector(
         target_action=node_main_test,
         log_file=performance_log_prefix_cpumem_pub,
-        timeout=(@PERF_TEST_RUNTIME@ // (1 / 1.5)))
+        timeout=int(@PERF_TEST_RUNTIME@ / (1 / 1.5)))
 
     node_relay_test = Node(
         package='performance_test', node_executable='perf_test', output='log',
@@ -181,7 +181,7 @@ def generate_test_description(ready_fn):
     system_metric_collector_sub = SystemMetricCollector(
         target_action=node_relay_test,
         log_file=performance_log_prefix_cpumem_sub,
-        timeout=(@PERF_TEST_RUNTIME@ // (1 / 1.5)))
+        timeout=int(@PERF_TEST_RUNTIME@ / (1 / 1.5)))
 
     return LaunchDescription([
         system_metric_collector_pub,

--- a/test/test_spinning.py.in
+++ b/test/test_spinning.py.in
@@ -109,7 +109,7 @@ def generate_test_description(ready_fn):
     node_metrics_collector = SystemMetricCollector(
         target_action=node_spinning_test,
         log_file=performance_log_prefix_cpumem,
-        timeout=(@PERF_TEST_RUNTIME@ // (1 / 1.5)))
+        timeout=int(@PERF_TEST_RUNTIME@ / (1 / 1.5)))
 
     return LaunchDescription([
         node_metrics_collector,


### PR DESCRIPTION
This change brings support for resolving launch substitutions to the SystemMetricCollector action's log_path and timeout arguments. It also makes the existing uses pass an `int` instead of a `float` as the timeout argument, which was a bug to begin with.