### PR TITLE
Set --disable-async correctly in 3 additional places

### DIFF
--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -120,23 +120,20 @@ def generate_test_description(ready_fn):
         prefix='performance_test_@TEST_NAME@_', text=True)[1]
 
     launch_description = []
-    args = [
+    arguments = [
         '-c', '@COMM@',
         '-t', '@PERF_TEST_TOPIC@',
         '--max_runtime', '@PERF_TEST_RUNTIME@',
         '--ignore', '3',
         '-l', performance_log_prefix,
-    ]
-
-    sync_env = {}
-    if '@SYNC_MODE@' == 'sync' and '@COMM@' != 'ROS2':
-        args.append('--disable_async')
+    ] + ([
+        '--disable-async',
+    ] if '@SYNC_MODE@' == 'sync' and '@COMM@' != 'ROS2' else [])
 
     nodes = []
 
     if @NUMBER_PROCESS@ == 2:
-        args.append('--roundtrip_mode')
-        args.append('Main')
+        arguments += ['--roundtrip_mode', 'Main']
 
         node_relay = Node(
           package='performance_test', node_executable='perf_test', output='log',
@@ -145,14 +142,16 @@ def generate_test_description(ready_fn):
               '-t', '@PERF_TEST_TOPIC@',
               '--max_runtime', '@PERF_TEST_RUNTIME@',
               '--roundtrip_mode', 'Relay',
-          ],
+          ] + ([
+              '--disable-async',
+          ] if '@SYNC_MODE@' == 'sync' and '@COMM@' != 'ROS2' else []),
         )
         launch_description.append(node_relay)
         nodes.append(node_relay)
 
     node_under_test = Node(
         package='performance_test', node_executable='perf_test', output='log',
-        arguments=args,
+        arguments=arguments,
     )
     nodes.append(node_under_test)
 

--- a/test/test_pub_sub.py.in
+++ b/test/test_pub_sub.py.in
@@ -156,7 +156,9 @@ def generate_test_description(ready_fn):
             '--rate', '5',
             '--roundtrip_mode', 'Main',
             '--ignore', '3',
-        ],
+        ] + ([
+            '--disable-async',
+        ] if '@SYNC_MODE@' == 'sync' and '@COMM@' != 'ROS2' else []),
     )
 
     system_metric_collector_pub = SystemMetricCollector(
@@ -174,7 +176,9 @@ def generate_test_description(ready_fn):
             '--rate', '5',
             '--roundtrip_mode', 'Relay',
             '--ignore', '3',
-        ],
+        ] + ([
+            '--disable-async',
+        ] if '@SYNC_MODE@' == 'sync' and '@COMM@' != 'ROS2' else []),
         additional_env={'RMW_IMPLEMENTATION': '@RMW_IMPLEMENTATION_SUB@'},
     )
 


### PR DESCRIPTION
Seems that pub_sub is completely missing this flag.

I'm not sure if the main node's performance is affected by whether the relay is synchronous or not, but I thought it best to specify there too.