### PR TITLE
Drop separate test for timeout

### DIFF
--- a/buildfarm_perf_tests/launch.py
+++ b/buildfarm_perf_tests/launch.py
@@ -19,6 +19,17 @@ from launch.events import matches_action
 from launch.events.process import ShutdownProcess
 from launch.substitutions import LocalSubstitution
 from launch_ros.actions import Node
+import launch_testing.asserts
+
+
+def assert_wait_for_successful_exit(proc_info, process, timeout):
+    """Ensure that a process exits succesfully in a certain amount of time."""
+    proc_info.assertWaitForShutdown(process, timeout=timeout)
+    launch_testing.asserts.assertExitCodes(
+        proc_info,
+        [launch_testing.asserts.EXIT_OK],
+        process,
+    )
 
 
 class SystemMetricCollector(Node):

--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -7,12 +7,13 @@ import sys
 import tempfile
 import unittest
 
+from buildfarm_perf_tests.launch import assert_wait_for_successful_exit
 from buildfarm_perf_tests.test_results import read_performance_test_csv
 from buildfarm_perf_tests.test_results import write_jenkins_plot_csv
-import launch
 from launch import LaunchDescription
+from launch.actions import OpaqueFunction
 from launch_ros.actions import Node
-import launch_testing
+import launch_testing.markers
 
 import matplotlib  # noqa: F401
 import matplotlib.pyplot as plt
@@ -115,6 +116,7 @@ def _raw_to_png(dataframe, png_path):
     plt.savefig(png_path[:-4] + '_histogram.png')
 
 
+@launch_testing.markers.keep_alive
 def generate_test_description(ready_fn):
     performance_log_prefix = tempfile.mkstemp(
         prefix='performance_test_@TEST_NAME@_', text=True)[1]
@@ -123,7 +125,6 @@ def generate_test_description(ready_fn):
     # we just need the prefix to be unique
     os.remove(performance_log_prefix)
 
-    launch_description = []
     arguments = [
         '-c', '@COMM@',
         '-t', '@PERF_TEST_TOPIC@',
@@ -150,7 +151,6 @@ def generate_test_description(ready_fn):
               '--disable-async',
           ] if '@SYNC_MODE@' == 'sync' and '@COMM@' != 'ROS2' else []),
         )
-        launch_description.append(node_relay)
         nodes.append(node_relay)
 
     node_under_test = Node(
@@ -159,35 +159,20 @@ def generate_test_description(ready_fn):
     )
     nodes.append(node_under_test)
 
-    launch_description.append(node_under_test)
-    launch_description.append(launch_testing.util.KeepAliveProc())
-    launch_description.append(launch.actions.OpaqueFunction(function=lambda context: ready_fn()))
-
-    return LaunchDescription(launch_description), locals()
+    return LaunchDescription(nodes + [
+        OpaqueFunction(function=lambda context: ready_fn()),
+    ]), locals()
 
 
-class PerformanceTestTermination(unittest.TestCase):
-
-    def test_termination_@TEST_NAME@(self, nodes, proc_info):
-        for node in nodes:
-            proc_info.assertWaitForShutdown(
-                process=node,
-                timeout=(@PERF_TEST_RUNTIME@ * 2))
-
-
-@launch_testing.post_shutdown_test()
 class PerformanceTestResults(unittest.TestCase):
 
     def test_results_@TEST_NAME@(
-            self, performance_log_prefix, nodes, proc_info):
+            self, proc_info, nodes, performance_log_prefix):
         self.addCleanup(_cleanUpLogs, performance_log_prefix + '*')
 
-        for node in nodes:
-            launch_testing.asserts.assertExitCodes(
-                proc_info,
-                [launch_testing.asserts.EXIT_OK],
-                node,
-            )
+        timeout = @PERF_TEST_RUNTIME@ * 2
+        for process in nodes:
+            assert_wait_for_successful_exit(proc_info, process, timeout)
 
         results_base_path = os.environ.get('PERF_TEST_RESULTS_BASE_PATH')
         if results_base_path:

--- a/test/test_pub_sub.py.in
+++ b/test/test_pub_sub.py.in
@@ -7,13 +7,15 @@ import sys
 import tempfile
 import unittest
 
+from buildfarm_perf_tests.launch import assert_wait_for_successful_exit
 from buildfarm_perf_tests.launch import SystemMetricCollector
 from buildfarm_perf_tests.test_results import read_performance_test_csv
 from buildfarm_perf_tests.test_results import write_jenkins_plot_csv
 from launch import LaunchDescription
 from launch.actions import OpaqueFunction
 from launch_ros.actions import Node
-import launch_testing
+import launch_testing.markers
+
 import matplotlib  # noqa: F401
 import matplotlib.pyplot as plt
 import numpy as np  # noqa: F401
@@ -128,6 +130,7 @@ def _raw_to_png(dataframe, dataframe_perf, png_path, mode, rmw_impl):
                 + mode + '_latency.png')
 
 
+@launch_testing.markers.keep_alive
 def generate_test_description(ready_fn):
     performance_log_cpumem_pub = tempfile.mkstemp(
         prefix='overhead_cpumem_pub_test_results_'
@@ -192,53 +195,32 @@ def generate_test_description(ready_fn):
         log_file=performance_log_cpumem_sub,
         timeout=int(@PERF_TEST_RUNTIME@ / (1 / 1.5)))
 
-    return LaunchDescription([
+    nodes = [
         system_metric_collector_pub,
         system_metric_collector_sub,
         node_main_test,
         node_relay_test,
-        launch_testing.util.KeepAliveProc(),
+    ]
+
+    return LaunchDescription(nodes + [
         OpaqueFunction(function=lambda context: ready_fn()),
     ]), locals()
 
 
-class PerformanceTestTermination(unittest.TestCase):
-
-    def test_termination_@TEST_NAME_PUB_SUB@(
-            self, system_metric_collector_sub, system_metric_collector_pub,
-            node_main_test, node_relay_test, proc_info):
-        proc_info.assertWaitForShutdown(process=system_metric_collector_sub,
-                                        timeout=(@PERF_TEST_RUNTIME@ * 2))
-        proc_info.assertWaitForShutdown(process=system_metric_collector_pub,
-                                        timeout=(@PERF_TEST_RUNTIME@ * 2))
-        proc_info.assertWaitForShutdown(process=node_main_test, timeout=(@PERF_TEST_RUNTIME@ * 2))
-        proc_info.assertWaitForShutdown(process=node_relay_test, timeout=(@PERF_TEST_RUNTIME@ * 2))
-
-
-@launch_testing.post_shutdown_test()
 class PerformanceTestResults(unittest.TestCase):
 
     def test_results_@TEST_NAME_PUB_SUB@(
-            self,
+            self, proc_info, nodes,
             performance_log_cpumem_pub, performance_log_cpumem_sub,
-            performance_log_prefix_pub, performance_log_prefix_sub,
-            proc_info, node_relay_test, node_main_test):
+            performance_log_prefix_pub, performance_log_prefix_sub):
         self.addCleanup(_cleanUpLogs, performance_log_prefix_pub + '*')
         self.addCleanup(_cleanUpLogs, performance_log_prefix_sub + '*')
         self.addCleanup(_cleanUpLogs, performance_log_cpumem_pub)
         self.addCleanup(_cleanUpLogs, performance_log_cpumem_sub)
 
-        launch_testing.asserts.assertExitCodes(
-            proc_info,
-            [launch_testing.asserts.EXIT_OK],
-            node_relay_test,
-        )
-
-        launch_testing.asserts.assertExitCodes(
-            proc_info,
-            [launch_testing.asserts.EXIT_OK],
-            node_main_test,
-        )
+        timeout = @PERF_TEST_RUNTIME@ * 2
+        for process in nodes:
+            assert_wait_for_successful_exit(proc_info, process, timeout)
 
         results_base_path = os.environ.get('PERF_TEST_RESULTS_BASE_PATH')
         performance_overhead_png = os.environ.get('PERFORMANCE_OVERHEAD_PNG')

--- a/test/test_spinning.py.in
+++ b/test/test_spinning.py.in
@@ -7,6 +7,7 @@ import sys
 import tempfile
 import unittest
 
+from buildfarm_perf_tests.launch import assert_wait_for_successful_exit
 from buildfarm_perf_tests.launch import SystemMetricCollector
 from buildfarm_perf_tests.test_results import read_performance_test_csv
 from buildfarm_perf_tests.test_results import write_jenkins_plot_csv
@@ -19,7 +20,8 @@ from launch.event_handlers import OnProcessStart
 from launch.events import matches_action
 from launch.events.process import ShutdownProcess
 from launch_ros.actions import Node
-import launch_testing
+import launch_testing.markers
+
 import matplotlib  # noqa: F401
 import matplotlib.pyplot as plt
 import numpy as np  # noqa: F401
@@ -89,6 +91,7 @@ def _raw_to_png(dataframe, png_path):
     plt.savefig(png_base + '_resident_anonymous_memory' + png_ext)
 
 
+@launch_testing.markers.keep_alive
 def generate_test_description(ready_fn):
     performance_log_cpumem = tempfile.mkstemp(
         prefix='overhead_node_test_results_@TEST_NAME@_',
@@ -112,38 +115,26 @@ def generate_test_description(ready_fn):
         log_file=performance_log_cpumem,
         timeout=int(@PERF_TEST_RUNTIME@ / (1 / 1.5)))
 
-    return LaunchDescription([
+    nodes = [
         node_metrics_collector,
         node_spinning_test,
+    ]
+
+    return LaunchDescription(nodes + [
         node_spinning_timer,
-        launch_testing.util.KeepAliveProc(),
         OpaqueFunction(function=lambda context: ready_fn()),
     ]), locals()
 
 
-class NodeSpinningTestTermination(unittest.TestCase):
-
-    def test_termination_@TEST_NAME@(
-            self, node_spinning_test, node_metrics_collector, proc_info):
-        proc_info.assertWaitForShutdown(process=node_spinning_test,
-                                        timeout=(@PERF_TEST_RUNTIME@ * 2))
-        proc_info.assertWaitForShutdown(process=node_metrics_collector,
-                                        timeout=(@PERF_TEST_RUNTIME@ * 2))
-
-
-@launch_testing.post_shutdown_test()
 class NodeSpinningTestResults(unittest.TestCase):
 
     def test_results_@TEST_NAME@(
-            self, performance_log_cpumem,
-            node_metrics_collector, proc_info):
+            self, proc_info, nodes, performance_log_cpumem):
         self.addCleanup(_cleanUpLogs, performance_log_cpumem)
 
-        launch_testing.asserts.assertExitCodes(
-            proc_info,
-            [launch_testing.asserts.EXIT_OK],
-            node_metrics_collector,
-        )
+        timeout = @PERF_TEST_RUNTIME@ * 2
+        for process in nodes:
+            assert_wait_for_successful_exit(proc_info, process, timeout)
 
         results_base_path = os.environ.get('PERF_TEST_RESULTS_BASE_PATH')
         if results_base_path:


### PR DESCRIPTION
This change brings us from two tests on the same LaunchDescription, with one being a post-shutdown test, to a single test that runs concurrently with the test and ensures that it does not hang.

This makes the three test files a bit shorter and easier to read.