### PR TITLE
Make list of RMWs configurable at build time

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -112,4 +112,9 @@ ament_flake8(TESTNAME "flake8_generated"
 )
 
 include(add_performance_tests.cmake)
-call_for_each_rmw_implementation(add_performance_tests)
+
+get_available_rmw_implementations(_RMW_IMPLEMENTATIONS)
+set(PERF_TEST_RMW_IMPLEMENTATIONS "${_RMW_IMPLEMENTATIONS}"
+  CACHE STRING "List of RMW implementations to test with")
+
+add_performance_tests("${PERF_TEST_RMW_IMPLEMENTATIONS}")


### PR DESCRIPTION
Default behavior is still the same - use all available RMWs.

This will make local testing easier to do - specify something like `--cmake-args -DPERF_TEST_RMW_IMPLEMENTATIONS=rmw_cyclonedds_cpp -DPERF_TEST_TOPICS=Array1k` and you'll get a narrow subset of the full test suite that can be run in just a few minutes, but covers all of the types of tests that this suite runs.