### PR TITLE
Strict latency test in 2 processes case

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This package defines some tests. On one hand it invokes `perf_test` from Apex.AI
 In this test we are running the Performance Test provided by Apex.AI. Right now we have [our own fork](https://github.com/ros2/performance_test) because there are some pending pull requests in the official gitlab repository.
 
 In this test we are measurement:
- - Average round-trip time
+ - Average latency
  - CPU usage (provided by Apex.AI tool)
  - Sent/Received packets per second
  - Total lost packets

--- a/templates/performance_test_1p_1k.txt
+++ b/templates/performance_test_1p_1k.txt
@@ -1,5 +1,5 @@
-  - title: Average Round-Trip Time
-    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
+  - title: Latency
+    description: "The figure shown above shows the average latency time in millisecond for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Milliseconds
     master_csv_name: plot-${random_number}.csv
     style: line

--- a/templates/performance_test_1p_multi.txt
+++ b/templates/performance_test_1p_multi.txt
@@ -1,5 +1,5 @@
-  - title: Latency Average Round-Trip Time (Array1k)
-    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
+  - title: Latency (Array1k)
+    description: "The figure shown above shows the average latency time in millisecond for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Milliseconds
     master_csv_name: plot-${random_number}.csv
     style: line
@@ -11,8 +11,8 @@
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 0
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
-  - title: Latency Average Round-Trip Time (Array4k)
-    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 4K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4K</li></ul>"
+  - title: Latency (Array4k)
+    description: "The figure shown above shows the average latency time in millisecond for different DDS vendors using a 4K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4K</li></ul>"
     y_axis_label: Milliseconds
     master_csv_name: plot-${random_number}1.csv
     style: line
@@ -24,8 +24,8 @@
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 0
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
-  - title: Latency Average Round-Trip Time (Array16k)
-    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 16K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 16K</li></ul>"
+  - title: Latency (Array16k)
+    description: "The figure shown above shows the average latency time in millisecond for different DDS vendors using a 16K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 16K</li></ul>"
     y_axis_label: Milliseconds
     master_csv_name: plot-${random_number}2.csv
     style: line
@@ -37,8 +37,8 @@
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 0
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
-  - title: Latency Average Round-Trip Time (Array32k)
-    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 32K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 32K</li></ul>"
+  - title: Latency (Array32k)
+    description: "The figure shown above shows the average latency time in millisecond for different DDS vendors using a 32K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 32K</li></ul>"
     y_axis_label: Milliseconds
     master_csv_name: plot-${random_number}3.csv
     style: line
@@ -50,8 +50,8 @@
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 0
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
-  - title: Latency Average Round-Trip Time (Array60k)
-    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 60K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 60K</li></ul>"
+  - title: Latency (Array60k)
+    description: "The figure shown above shows the average latency time in millisecond for different DDS vendors using a 60K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 60K</li></ul>"
     y_axis_label: Milliseconds
     master_csv_name: plot-${random_number}4.csv
     style: line
@@ -63,8 +63,8 @@
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 0
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
-  - title: Latency Average Round-Trip Time (PointCloud512k)
-    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 512K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 512K</li></ul>"
+  - title: Latency (PointCloud512k)
+    description: "The figure shown above shows the average latency time in millisecond for different DDS vendors using a 512K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 512K</li></ul>"
     y_axis_label: Milliseconds
     master_csv_name: plot-${random_number}5.csv
     style: line
@@ -76,8 +76,8 @@
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 0
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
-  - title: Latency Average Round-Trip Time (Array1m)
-    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 1M array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1M</li></ul>"
+  - title: Latency (Array1m)
+    description: "The figure shown above shows the average latency time in millisecond for different DDS vendors using a 1M array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1M</li></ul>"
     y_axis_label: Milliseconds
     master_csv_name: plot-${random_number}6.csv
     style: line
@@ -89,8 +89,8 @@
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 0
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
-  - title: Latency Average Round-Trip Time (Array2m)
-    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 2M array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 2M</li></ul>"
+  - title: Latency (Array2m)
+    description: "The figure shown above shows the average latency time in millisecond for different DDS vendors using a 2M array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 2M</li></ul>"
     y_axis_label: Milliseconds
     master_csv_name: plot-${random_number}7.csv
     style: line

--- a/templates/performance_test_2p_1k.txt
+++ b/templates/performance_test_2p_1k.txt
@@ -1,5 +1,5 @@
-  - title: Average Round-Trip Time
-    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
+  - title: Latency
+    description: "The figure shown above shows the average latency time in millisecond for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Milliseconds
     master_csv_name: plot-${random_number}.csv
     style: line

--- a/templates/performance_test_2p_multi.txt
+++ b/templates/performance_test_2p_multi.txt
@@ -1,5 +1,5 @@
-  - title: Latency Average Round-Trip Time (Array1k)
-    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
+  - title: Latency (Array1k)
+    description: "The figure shown above shows the average latency time in millisecond for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Milliseconds
     master_csv_name: plot-${random_number}.csv
     style: line
@@ -11,8 +11,8 @@
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 0
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
-  - title: Latency Average Round-Trip Time (Array4k)
-    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 4K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 4K</li></ul>"
+  - title: Latency (Array4k)
+    description: "The figure shown above shows the average latency time in millisecond for different DDS vendors using a 4K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 4K</li></ul>"
     y_axis_label: Milliseconds
     master_csv_name: plot-${random_number}1.csv
     style: line
@@ -24,8 +24,8 @@
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 0
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
-  - title: Latency Average Round-Trip Time (Array16k)
-    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 16K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 16K</li></ul>"
+  - title: Latency (Array16k)
+    description: "The figure shown above shows the average latency time in millisecond for different DDS vendors using a 16K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 16K</li></ul>"
     y_axis_label: Milliseconds
     master_csv_name: plot-${random_number}2.csv
     style: line
@@ -37,8 +37,8 @@
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 0
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
-  - title: Latency Average Round-Trip Time (Array32k)
-    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 32K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 32K</li></ul>"
+  - title: Latency (Array32k)
+    description: "The figure shown above shows the average latency time in millisecond for different DDS vendors using a 32K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 32K</li></ul>"
     y_axis_label: Milliseconds
     master_csv_name: plot-${random_number}3.csv
     style: line
@@ -50,8 +50,8 @@
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 0
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
-  - title: Latency Average Round-Trip Time (Array60k)
-    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 60K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 60K</li></ul>"
+  - title: Latency (Array60k)
+    description: "The figure shown above shows the average latency time in millisecond for different DDS vendors using a 60K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 60K</li></ul>"
     y_axis_label: Milliseconds
     master_csv_name: plot-${random_number}4.csv
     style: line
@@ -63,8 +63,8 @@
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 0
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
-  - title: Latency Average Round-Trip Time (PointCloud512k)
-    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 512K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 512K</li></ul>"
+  - title: Latency (PointCloud512k)
+    description: "The figure shown above shows the average latency time in millisecond for different DDS vendors using a 512K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 512K</li></ul>"
     y_axis_label: Milliseconds
     master_csv_name: plot-${random_number}5.csv
     style: line
@@ -76,8 +76,8 @@
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 0
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
-  - title: Latency Average Round-Trip Time (Array1m)
-    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 1M array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1M</li></ul>"
+  - title: Latency (Array1m)
+    description: "The figure shown above shows the average latency time in millisecond for different DDS vendors using a 1M array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1M</li></ul>"
     y_axis_label: Milliseconds
     master_csv_name: plot-${random_number}6.csv
     style: line
@@ -89,8 +89,8 @@
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 0
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
-  - title: Latency Average Round-Trip Time (Array2m)
-    description: "The figure shown above shows the average round-trip time in milisecond for different DDS vendors using a 2M array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 2M</li></ul>"
+  - title: Latency (Array2m)
+    description: "The figure shown above shows the average latency time in millisecond for different DDS vendors using a 2M array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 2M</li></ul>"
     y_axis_label: Milliseconds
     master_csv_name: plot-${random_number}7.csv
     style: line

--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -143,7 +143,7 @@ def generate_test_description(ready_fn):
           node_executable='perf_test',
           output='log',
           arguments=arguments + [
-              '-s', '0'
+              '-s', '0',
           ],
         )
         nodes.append(node_pub)

--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -130,7 +130,6 @@ def generate_test_description(ready_fn):
         '-t', '@PERF_TEST_TOPIC@',
         '--max_runtime', '@PERF_TEST_RUNTIME@',
         '--ignore', '3',
-        '-l', performance_log_prefix,
     ] + ([
         '--disable-async',
     ] if '@SYNC_MODE@' == 'sync' and '@COMM@' != 'ROS2' else [])
@@ -138,24 +137,33 @@ def generate_test_description(ready_fn):
     nodes = []
 
     if @NUMBER_PROCESS@ == 2:
-        arguments += ['--roundtrip_mode', 'Main']
-
-        node_relay = Node(
-          package='performance_test', node_executable='perf_test', output='log',
-          arguments=[
-              '-c', '@COMM@',
-              '-t', '@PERF_TEST_TOPIC@',
-              '--max_runtime', '@PERF_TEST_RUNTIME@',
-              '--roundtrip_mode', 'Relay',
-          ] + ([
-              '--disable-async',
-          ] if '@SYNC_MODE@' == 'sync' and '@COMM@' != 'ROS2' else []),
+        # Publisher node. It has 0 subscribers
+        node_pub = Node(
+          package='performance_test',
+          node_executable='perf_test',
+          output='log',
+          arguments=arguments + [
+              '-s', '0'
+          ],
         )
-        nodes.append(node_relay)
+        nodes.append(node_pub)
 
+        # Add 0-publishers flag to arguments for node_under_test, which in the
+        # case of 2 processes will be a subscriber.
+        arguments += ['-p', '0']
+
+    # node_under_test is the node in charge of logging the results, since the
+    # measurements are always taken in the subscriber. This node behaves
+    # differently depending on the number of processes involved:
+    #   - 1 process: The node has a publisher and a subscriber
+    #   - 2 processes: The node only has a subscriber
     node_under_test = Node(
-        package='performance_test', node_executable='perf_test', output='log',
-        arguments=arguments,
+        package='performance_test',
+        node_executable='perf_test',
+        output='log',
+        arguments=arguments + [
+            '-l', performance_log_prefix,
+        ],
     )
     nodes.append(node_under_test)
 


### PR DESCRIPTION
This PR changes the testing paradigm for the two-process cases to mimic that of the single process ones. Now, the two-process tests issue one process with one publisher, and another one with one subscriber. This way, the measurements are taken on a one-way trip (just as in the single process tests), instead of round-trip. With it, the results of 1 vs 2 processes can be compared to really see how much difference does it make to have publisher and subscriber under the same process.

Signed-off-by: EduPonz <eduardoponz@eprosima.com>