### PR TITLE
Add larger messages to performance tests, add lost messages plots

### DIFF
--- a/buildfarm_perf_tests/generate_config_yaml.py
+++ b/buildfarm_perf_tests/generate_config_yaml.py
@@ -56,7 +56,7 @@ def performance_test(file_output, ci_name):
 
     _fill_performance_test(file_output,
                            os.path.join(templates_path, 'performance_test_1p_1k.txt'),
-                           'Performance One Process Test Results (Array1k)',
+                           'Performance One Process Test Results (Array1k):',
                            ci_name)
     _fill_performance_test(file_output,
                            os.path.join(templates_path, 'performance_test_1p_multi.txt'),
@@ -64,7 +64,7 @@ def performance_test(file_output, ci_name):
                            ci_name)
     _fill_performance_test(file_output,
                            os.path.join(templates_path, 'performance_test_2p_1k.txt'),
-                           'Performance Two Processes Test Results (Array1k)',
+                           'Performance Two Processes Test Results (Array1k):',
                            ci_name)
     _fill_performance_test(file_output,
                            os.path.join(templates_path, 'performance_test_2p_multi.txt'),

--- a/templates/overhead_physical_memory.txt
+++ b/templates/overhead_physical_memory.txt
@@ -1,30 +1,30 @@
-- title: Simple Pub ${rmw_implementation} Physical Memory
-  description: "The figure shown above shows the physical memory in Mb used by the publisher. The publisher is set to <b>${rmw_implementation} </b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
-  y_axis_label: Mb
-  master_csv_name: plot-${random_number}.csv
-  style: line
-  num_builds: 10
-  y_axis_exclude_zero: True
-  y_axis_minimum: 0
-  y_axis_maximum: 100
-  data_series:
-  - data_file: ws/test_results/buildfarm_perf_tests/overhead_test_results_${rmw_implementation}_*_pub.csv
-    data_type: csv
-    selection_flag: INCLUDE_BY_COLUMN
-    selection_value: 8
-    url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_test_results_%name%_publisher_physical_memory.png
-- title: Simple Sub ${rmw_implementation} Physical Memory
-  description: "The figure shown above shows the physical memory in Mb used by the subscriber. The publisher is set to <b>${rmw_implementation} </b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
-  y_axis_label: Mb
-  master_csv_name: plot-${random_number}1.csv
-  style: line
-  num_builds: 10
-  y_axis_exclude_zero: True
-  y_axis_minimum: 0
-  y_axis_maximum: 100
-  data_series:
-  - data_file: ws/test_results/buildfarm_perf_tests/overhead_test_results_${rmw_implementation}_*_sub.csv
-    data_type: csv
-    selection_flag: INCLUDE_BY_COLUMN
-    selection_value: 8
-    url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_test_results_%name%_subscriber_physical_memory.png
+  - title: Simple Pub ${rmw_implementation} Physical Memory
+    description: "The figure shown above shows the physical memory in Mb used by the publisher. The publisher is set to <b>${rmw_implementation} </b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Mb
+    master_csv_name: plot-${random_number}.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    y_axis_minimum: 0
+    y_axis_maximum: 100
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/overhead_test_results_${rmw_implementation}_*_pub.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 8
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_test_results_%name%_publisher_physical_memory.png
+  - title: Simple Sub ${rmw_implementation} Physical Memory
+    description: "The figure shown above shows the physical memory in Mb used by the subscriber. The publisher is set to <b>${rmw_implementation} </b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Mb
+    master_csv_name: plot-${random_number}1.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    y_axis_minimum: 0
+    y_axis_maximum: 100
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/overhead_test_results_${rmw_implementation}_*_sub.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 8
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_test_results_%name%_subscriber_physical_memory.png

--- a/templates/overhead_round_trip.txt
+++ b/templates/overhead_round_trip.txt
@@ -1,5 +1,5 @@
   - title: Simple Pub ${rmw_implementation} Average Round-Trip Time
-    description: "The figure shown above shows the average round-trip time in milisecond. The publisher is set to <b>rmw_fastrtps_cpp </b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
+    description: "The figure shown above shows the average round-trip time in milisecond. The publisher is set to <b>${rmw_implementation} </b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Milliseconds
     master_csv_name: plot-${random_number}.csv
     style: line

--- a/templates/overhead_virtual_memory.txt
+++ b/templates/overhead_virtual_memory.txt
@@ -1,32 +1,32 @@
-  - title: Simple Pub ${rmw_implementation} Virtual Memory
-    description: "The figure shown above shows the virtual memory in Mb used by the publisher. The publisher is set to <b>${rmw_implementation}</b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
+- title: Simple Pub ${rmw_implementation} Virtual Memory
+  description: "The figure shown above shows the virtual memory in Mb used by the publisher. The publisher is set to <b>${rmw_implementation}</b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
+  y_axis_label: Mb
+  num_builds: 50
+  master_csv_name: plot-${random_number}.csv
+  style: line
+  num_builds: 10
+  y_axis_exclude_zero: True
+  y_axis_minimum: 0
+  y_axis_maximum: 1000
+  data_series:
+  - data_file: ws/test_results/buildfarm_perf_tests/overhead_test_results_${rmw_implementation}_*_pub.csv
+    data_type: csv
+    selection_flag: INCLUDE_BY_COLUMN
+    selection_value: 2
+    url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_test_results_%name%_publisher_virtual_memory.png
+- title: Simple Sub ${rmw_implementation} Virtual Memory
+    description: "The figure shown above shows the virtual memory in Mb used by the subscriber. The publisher is set to <b>${rmw_implementation}</b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Mb
     num_builds: 50
-    master_csv_name: plot-${random_number}.csv
+    master_csv_name: plot-${random_number}1.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
     y_axis_minimum: 0
     y_axis_maximum: 1000
     data_series:
-    - data_file: ws/test_results/buildfarm_perf_tests/overhead_test_results_${rmw_implementation}_*_pub.csv
+    - data_file: ws/test_results/buildfarm_perf_tests/overhead_test_results_${rmw_implementation}_*_sub.csv
       data_type: csv
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 2
-      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_test_results_%name%_publisher_virtual_memory.png
-  - title: Simple Sub ${rmw_implementation} Virtual Memory
-      description: "The figure shown above shows the virtual memory in Mb used by the subscriber. The publisher is set to <b>${rmw_implementation}</b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
-      y_axis_label: Mb
-      num_builds: 50
-      master_csv_name: plot-${random_number}1.csv
-      style: line
-      num_builds: 10
-      y_axis_exclude_zero: True
-      y_axis_minimum: 0
-      y_axis_maximum: 1000
-      data_series:
-      - data_file: ws/test_results/buildfarm_perf_tests/overhead_test_results_${rmw_implementation}_*_sub.csv
-        data_type: csv
-        selection_flag: INCLUDE_BY_COLUMN
-        selection_value: 2
-        url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_test_results_%name%_subscriber_virtual_memory.png
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/overhead_test_results_%name%_subscriber_virtual_memory.png

--- a/templates/performance_test_1p_multi.txt
+++ b/templates/performance_test_1p_multi.txt
@@ -206,3 +206,107 @@
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 10
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Lost packets  (Array1k)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}16.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_histogram.png
+  - title: Lost packets  (Array4k)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 4K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4K</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}17.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array4k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_histogram.png
+  - title: Lost packets  (Array16k)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 16K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 16K</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}18.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array16k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_histogram.png
+  - title: Lost packets  (Array32k)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 32K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 32K</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}19.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array32k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_histogram.png
+  - title: Lost packets  (Array60k)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 64K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 60K</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}20.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array60k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_histogram.png
+  - title: Lost packets  (PointCloud512k)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 512K point cloud message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 512k</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}21.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_PointCloud512k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_histogram.png
+  - title: Lost packets  (Array1m)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 1m array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1m</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}22.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_histogram.png
+  - title: Lost packets  (Array2m)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 1m array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 2m</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}23.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array2m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_histogram.png

--- a/templates/performance_test_1p_multi.txt
+++ b/templates/performance_test_1p_multi.txt
@@ -102,6 +102,45 @@
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 0
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Average Single-Trip Time (Array4m)
+    description: "The figure shown above shows the average single-trip time in milisecond for different DDS vendors using a 4M array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4M</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}24.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array4m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Average Single-Trip Time (Array8m)
+    description: "The figure shown above shows the average single-trip time in milisecond for different DDS vendors using a 8M array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 8M</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}25.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array8m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Average Single-Trip Time (PointCloud8m)
+    description: "The figure shown above shows the average single-trip time in milisecond for different DDS vendors using a 8M point cloud message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 8M</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}26.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_PointCloud8m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
   - title: Throughput (Array1k)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Mbits/s
@@ -206,6 +245,45 @@
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 10
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (Array4m)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 4M array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4M</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}27.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array4m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (Array8m)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 8M array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 8M</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}28.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array8m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (PointCloud8m)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 8M point cloud message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 8M</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}29.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_PointCloud8m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
   - title: Lost packets  (Array1k)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Number
@@ -298,7 +376,7 @@
       selection_value: 6
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_histogram.png
   - title: Lost packets  (Array2m)
-    description: "The figure shown above shows the lost packets for different DDS vendors using a 1m array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 2m</li></ul>"
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 2m array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 2m</li></ul>"
     y_axis_label: Number
     master_csv_name: plot-${random_number}23.csv
     style: line
@@ -306,6 +384,45 @@
     y_axis_exclude_zero: True
     data_series:
     - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array2m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_histogram.png
+  - title: Lost packets  (Array4m)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 4m array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4m</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}30.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array4m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_histogram.png
+  - title: Lost packets  (Array8m)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 8m array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 8m</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}31.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array8m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_histogram.png
+  - title: Lost packets  (PointCloud8m)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 8m point cloud message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 8m</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}32.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_PointCloud8m.csv
       data_type: csv
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 6

--- a/templates/performance_test_2p_multi.txt
+++ b/templates/performance_test_2p_multi.txt
@@ -206,3 +206,107 @@
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 10
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Lost packets  (Array1k)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}16.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_histogram.png
+  - title: Lost packets  (Array4k)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 4K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4K</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}17.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array4k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_histogram.png
+  - title: Lost packets  (Array16k)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 16K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 16K</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}18.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array16k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_histogram.png
+  - title: Lost packets  (Array32k)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 32K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 32K</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}19.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array32k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_histogram.png
+  - title: Lost packets  (Array60k)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 64K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 60K</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}20.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array60k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_histogram.png
+  - title: Lost packets  (PointCloud512k)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 512K point cloud message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 512k</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}21.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_PointCloud512k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_histogram.png
+  - title: Lost packets  (Array1m)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 1m array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1m</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}22.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_histogram.png
+  - title: Lost packets  (Array2m)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 1m array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 2m</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}23.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array2m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_histogram.png

--- a/templates/performance_test_2p_multi.txt
+++ b/templates/performance_test_2p_multi.txt
@@ -64,7 +64,7 @@
       selection_value: 0
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
   - title: Average Single-Trip Time (PointCloud512k)
-    description: "The figure shown above shows the average latency time in millisecond for different DDS vendors using a 512K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 512K</li></ul>"
+    description: "The figure shown above shows the average latency time in milisecond for different DDS vendors using a 512K point cloud message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 512K</li></ul>"
     y_axis_label: Milliseconds
     master_csv_name: plot-${random_number}5.csv
     style: line
@@ -98,6 +98,45 @@
     exclZero: False
     data_series:
     - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array2m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Average Single-Trip Time (Array4m)
+    description: "The figure shown above shows the average single-trip time in milisecond for different DDS vendors using a 4M array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 4M</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}24.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array4m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Average Single-Trip Time (Array8m)
+    description: "The figure shown above shows the average single-trip time in milisecond for different DDS vendors using a 8M array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 8M</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}25.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array8m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Average Single-Trip Time (PointCloud8m)
+    description: "The figure shown above shows the average single-trip time in milisecond for different DDS vendors using a 8M point cloud message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 8M</li></ul>"
+    y_axis_label: Milliseconds
+    master_csv_name: plot-${random_number}26.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_PointCloud8m.csv
       data_type: csv
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 0
@@ -168,7 +207,7 @@
       selection_value: 10
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
   - title: Throughput (PointCloud512k)
-    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 512K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 512K</li></ul>"
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 512K point cloud message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 512K</li></ul>"
     y_axis_label: Mbits/s
     master_csv_name: plot-${random_number}13.csv
     style: line
@@ -202,6 +241,45 @@
     exclZero: False
     data_series:
     - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array2m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (Array4m)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 4M array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4M</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}27.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array4m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (Array8m)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 8M array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 8M</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}28.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array8m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (PointCloud8m)
+    description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 8M point cloud message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 8M</li></ul>"
+    y_axis_label: Mbits/s
+    master_csv_name: plot-${random_number}29.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_PointCloud8m.csv
       data_type: csv
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 10
@@ -298,7 +376,7 @@
       selection_value: 6
       url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_histogram.png
   - title: Lost packets  (Array2m)
-    description: "The figure shown above shows the lost packets for different DDS vendors using a 1m array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 2m</li></ul>"
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 2m array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 2m</li></ul>"
     y_axis_label: Number
     master_csv_name: plot-${random_number}23.csv
     style: line
@@ -306,6 +384,45 @@
     y_axis_exclude_zero: True
     data_series:
     - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array2m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_histogram.png
+  - title: Lost packets  (Array4m)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 4m array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4m</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}30.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array4m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_histogram.png
+  - title: Lost packets  (Array8m)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 8m array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 8m</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}31.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array8m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 6
+      url: /job/${ci_name}/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_histogram.png
+  - title: Lost packets  (PointCloud8m)
+    description: "The figure shown above shows the lost packets for different DDS vendors using a 8m point cloud message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 8m</li></ul>"
+    y_axis_label: Number
+    master_csv_name: plot-${random_number}32.csv
+    style: line
+    num_builds: 10
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_PointCloud8m.csv
       data_type: csv
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 6

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,9 +12,12 @@ set(PERF_TEST_TOPICS
   Array16k
   Array32k
   Array60k
-  PointCloud512k
   Array1m
   Array2m
+  Array4m
+  Array8m
+  PointCloud512k
+  PointCloud8m
   CACHE STRING "List of perf_test topics to run tests with"
 )
 
@@ -74,9 +77,9 @@ set(PERF_TEST_SKIP_rmw_connext_cpp_sync ON
   CACHE BOOL "Skip rmw_connext_cpp sync tests")
 
 # Fast-RTPS ros2-eloquent branch (1.9.3 + bugfixes) does not support synchronous
-# sending of fragments. This means that in that branch, topics PointCloud512k,
-# Array1m, and Array2m cannot be sent synchronously in ROS 2 Eloquent (either
-# from standalone Fast-RTPS, or from rmw_fastrtps_*)
+# sending of fragments. This means that in that branch, topics Array1m,
+# Array2m, Array4m, Array8m, PointCloud512k, PointCloud8m cannot be sent synchronously in
+# ROS 2 Eloquent (either from standalone Fast-RTPS, or from rmw_fastrtps_*)
 # https://github.com/ros2/buildfarm_perf_tests/pull/26#discussion_r393229707
 set(FASTRTPS_SYNC_SKIP_ROS_DISTROS
   "dashing"
@@ -84,7 +87,7 @@ set(FASTRTPS_SYNC_SKIP_ROS_DISTROS
 )
 if("$ENV{ROS_DISTRO}" IN_LIST FASTRTPS_SYNC_SKIP_ROS_DISTROS)
   foreach(skip_rmw rmw_fastrtps_cpp rmw_fastrtps_dynamic_cpp FastRTPS)
-    foreach(skip_topic Array1m Array2m PointCloud512k)
+    foreach(skip_topic Array1m Array2m Array4m Array8m PointCloud512k PointCloud8m)
       set(PERF_TEST_SKIP_${skip_rmw}_sync_${skip_topic} ON
         CACHE BOOL "Skip ${skip_rmw} sync ${skip_topic} tests")
     endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -76,6 +76,11 @@ set(PERF_TEST_SKIP_rmw_opensplice_cpp_sync ON
 set(PERF_TEST_SKIP_rmw_connext_cpp_sync ON
   CACHE BOOL "Skip rmw_connext_cpp sync tests")
 
+foreach(large_data_topic Array4m Array8m PointCloud8m)
+  set(PERF_TEST_KEEP_LAST_${large_data_topic} ON
+    CACHE BOOL "Use keep last, depth 10 history in ${large_data_topic} tests")
+endforeach()
+
 # Fast-RTPS ros2-eloquent branch (1.9.3 + bugfixes) does not support synchronous
 # sending of fragments. This means that in that branch, topics Array1m,
 # Array2m, Array4m, Array8m, PointCloud512k, PointCloud8m cannot be sent synchronously in

--- a/test/add_performance_tests.cmake
+++ b/test/add_performance_tests.cmake
@@ -82,7 +82,7 @@ function(add_performance_test
 
     set(KEEP_LAST FALSE)
     set(HISTORY_DEPTH "")
-    if("${PERF_TEST_TOPIC}" MATCHES "Array4m|Array8m|PointCloud8m")
+    if("${PERF_TEST_KEEP_LAST_${PERF_TEST_TOPIC}}")
       set(KEEP_LAST TRUE)
       set(HISTORY_DEPTH 10)
     endif()

--- a/test/add_performance_tests.cmake
+++ b/test/add_performance_tests.cmake
@@ -80,6 +80,13 @@ function(add_performance_test
     set(TEST_ENV_TOPIC ${TEST_ENV})
     list(APPEND TEST_ENV_TOPIC ${PERF_TEST_ENV_${TEST_NAME_SYNC_TOPIC}})
 
+    set(KEEP_LAST FALSE)
+    set(HISTORY_DEPTH "")
+    if("${PERF_TEST_TOPIC}" MATCHES "Array4m|Array8m|PointCloud8m")
+      set(KEEP_LAST TRUE)
+      set(HISTORY_DEPTH 10)
+    endif()
+
     set(NUMBER_PROCESS "1")
 
     get_filename_component(

--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -132,7 +132,11 @@ def generate_test_description(ready_fn):
         '--ignore', '3',
     ] + ([
         '--disable-async',
-    ] if '@SYNC_MODE@' == 'sync' and '@COMM@' != 'ROS2' else [])
+    ] if '@SYNC_MODE@' == 'sync' and '@COMM@' != 'ROS2' else []) + ([
+        '--keep_last'
+    ] if '@KEEP_LAST@' == 'TRUE' else []) + ([
+        '--history_depth', '@HISTORY_DEPTH@'
+    ] if '@HISTORY_DEPTH@' != '' else [])
 
     nodes = []
 

--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -133,9 +133,9 @@ def generate_test_description(ready_fn):
     ] + ([
         '--disable-async',
     ] if '@SYNC_MODE@' == 'sync' and '@COMM@' != 'ROS2' else []) + ([
-        '--keep_last'
+        '--keep_last',
     ] if '@KEEP_LAST@' == 'TRUE' else []) + ([
-        '--history_depth', '@HISTORY_DEPTH@'
+        '--history_depth', '@HISTORY_DEPTH@',
     ] if '@HISTORY_DEPTH@' != '' else [])
 
     nodes = []


### PR DESCRIPTION
Summary of the PR:

* Adds larger messages to the performance tests that are run (Array4m, Array8m, PointCloud8m)
* Adds lost messages plots in multi-sized 1p/2p templates
* Corrects error in labels of previous plots
* Minimal modification in templates/generate_yaml script, to avoid manual edition.

It would be nice to avoid some of the repetition of the existing templates (i.e. templatize this further), though that is not a goal of this PR.

Requires https://github.com/ros2/performance_test/pull/15.