### PR TITLE
Removed warning "ignoring return value" write()

### DIFF
--- a/src/main_measurements.cpp
+++ b/src/main_measurements.cpp
@@ -27,7 +27,11 @@ static void post_sentinel(int signum)
 {
   (void)signum;
   const char msg[] = "\nGot signal - shutting down\n";
-  write(STDERR_FILENO, msg, sizeof(msg));
+  ssize_t ret = write(STDERR_FILENO, msg, sizeof(msg));
+  if (ret == -1) {
+    std::cerr << "write() failed" << std::endl;
+    exit(1);
+  }
   sem_post(&sentinel);
 }
 


### PR DESCRIPTION
Related with this issue https://github.com/ros2/buildfarm_perf_tests/issues/66

Signed-off-by: ahcorde <ahcorde@gmail.com>