### PR TITLE
Explicitly ignore return value from write()

### DIFF
--- a/src/main_measurements.cpp
+++ b/src/main_measurements.cpp
@@ -27,7 +27,7 @@ static void post_sentinel(int signum)
 {
   (void)signum;
   const char msg[] = "\nGot signal - shutting down\n";
-  write(STDERR_FILENO, msg, sizeof(msg));
+  (void)!write(STDERR_FILENO, msg, sizeof(msg));
   sem_post(&sentinel);
 }
 


### PR DESCRIPTION
If this message fails to write, there really isn't anything we can do about it. The message isn't strictly necessary, but is nice to have.

Should resolve warnings from -Wunused-result.

Note that `write()` has the `warn_unused_result` attribute, so casting to `(void)` isn't enough. The method employed here is to perform a logical operation on the value and discard the result.

[![Build Status](http://build.ros2.org/buildStatus/icon?job=Fci__overlay_ubuntu_focal_amd64&build=30)](http://build.ros2.org/view/Fci/job/Fci__overlay_ubuntu_focal_amd64/30/)

Alternative to #67
Closes #66