### PR TITLE
use deterministic names for .csv files

### DIFF
--- a/buildfarm_perf_tests/generate_config_yaml.py
+++ b/buildfarm_perf_tests/generate_config_yaml.py
@@ -26,16 +26,23 @@ def _add_line_plot_overhead(file_output, template_name, label, rmw_implementatio
 
     file_output.write('  ' + label + '\n')
 
+    name = os.path.splitext(os.path.basename(template_name))[0]
     for rmw_implementation in rmw_implementations:
-        random_number = _rand_x_digit_num(19)
+        random_number = _check_unique_identifier(name + '_' + rmw_implementation)
         file_output.write(content.substitute(rmw_implementation=rmw_implementation,
                                              ci_name=ci_name,
                                              random_number=random_number))
 
 
-def _rand_x_digit_num(x):
-    """Return an X digit number, leading_zeroes returns a string, otherwise int."""
-    return '{0:0{x}d}'.format(random.randint(0, 10**x-1), x=x)
+_unique_identifiers = set()
+
+
+def _check_unique_identifier(name):
+    global _unique_identifiers
+    unique_identifier = name#str(len(_unique_identifiers))
+    assert unique_identifier not in _unique_identifiers, unique_identifier
+    _unique_identifiers.add(unique_identifier)
+    return unique_identifier
 
 
 def _fill_performance_test(file_output, template_name, label, ci_name):
@@ -45,7 +52,8 @@ def _fill_performance_test(file_output, template_name, label, ci_name):
 
     file_output.write('  ' + label + '\n')
 
-    random_number = _rand_x_digit_num(19)
+    name = os.path.splitext(os.path.basename(template_name))[0]
+    random_number = _check_unique_identifier(name)
     file_output.write(content.substitute(ci_name=ci_name,
                                          random_number=random_number))
 
@@ -80,7 +88,7 @@ def node_spinnnig(file_output, ci_name):
 
     file_output.write('  Node Spinnig Results:\n')
 
-    random_number = _rand_x_digit_num(19)
+    random_number = _check_unique_identifier('node_spinning')
     file_output.write(content.substitute(ci_name=ci_name,
                                          random_number=random_number))
 

--- a/buildfarm_perf_tests/generate_config_yaml.py
+++ b/buildfarm_perf_tests/generate_config_yaml.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import random
 from string import Template
 
 from ament_index_python import get_package_share_directory

--- a/buildfarm_perf_tests/generate_config_yaml.py
+++ b/buildfarm_perf_tests/generate_config_yaml.py
@@ -38,7 +38,7 @@ _unique_identifiers = set()
 
 def _check_unique_identifier(name):
     global _unique_identifiers
-    unique_identifier = name#str(len(_unique_identifiers))
+    unique_identifier = name
     assert unique_identifier not in _unique_identifiers, unique_identifier
     _unique_identifiers.add(unique_identifier)
     return unique_identifier

--- a/templates/node_spinning.txt
+++ b/templates/node_spinning.txt
@@ -16,7 +16,7 @@
   - title: Node Spinning CPU Usage
     description: "The figure shown above shows the CPU usage in % used by a single node spinning. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li></ul>"
     y_axis_label: Utilization (%)
-    master_csv_name: plot-${random_number}1.csv
+    master_csv_name: plot-${random_number}-1.csv
     style: line
     num_builds: 10
     y_axis_minimum: 0
@@ -31,7 +31,7 @@
   - title: Node Spinning Physical Memory
     description: "The figure shown above shows the physical memory in Mb used by a single node spinning. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li></ul>"
     y_axis_label: Mb
-    master_csv_name: plot-${random_number}2.csv
+    master_csv_name: plot-${random_number}-2.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -46,7 +46,7 @@
   - title: Node Spinning Resident Anonymous Memory
     description: "The figure shown above shows the resident anonymous memory in Mb used by a single node spinning. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li></ul>"
     y_axis_label: Mb
-    master_csv_name: plot-${random_number}3.csv
+    master_csv_name: plot-${random_number}-3.csv
     style: line
     num_builds: 10
     y_axis_minimum: 0

--- a/templates/overhead_cpu_usage.txt
+++ b/templates/overhead_cpu_usage.txt
@@ -16,7 +16,7 @@
   - title: Simple Sub ${rmw_implementation} CPU Usage
     description: "The figure shown above shows the CPU usage in % used by the subscriber. The publisher is set to <b>${rmw_implementation} </b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Utilization (%)
-    master_csv_name: plot-${random_number}1.csv
+    master_csv_name: plot-${random_number}-1.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True

--- a/templates/overhead_lost_packets.txt
+++ b/templates/overhead_lost_packets.txt
@@ -1,7 +1,7 @@
   - title: Simple Pub ${rmw_implementation} Lost packets
     description: "The figure shown above shows the lost packets. The publisher is set to <b>${rmw_implementation}</b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Total Count
-    master_csv_name: plot-$random_number.csv
+    master_csv_name: plot-${random_number}.csv
     style: line
     num_builds: 10
     y_axis_minimum: 0

--- a/templates/overhead_physical_memory.txt
+++ b/templates/overhead_physical_memory.txt
@@ -16,7 +16,7 @@
   - title: Simple Sub ${rmw_implementation} Physical Memory
     description: "The figure shown above shows the physical memory in Mb used by the subscriber. The publisher is set to <b>${rmw_implementation} </b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Mb
-    master_csv_name: plot-${random_number}1.csv
+    master_csv_name: plot-${random_number}-1.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True

--- a/templates/overhead_received_packets.txt
+++ b/templates/overhead_received_packets.txt
@@ -1,7 +1,7 @@
   - title: Simple Pub ${rmw_implementation} Received packets per second
     description: "The figure shown above shows the received packets per second. The publisher is set to <b>${rmw_implementation}</b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Packets per second
-    master_csv_name: plot-$random_number.csv
+    master_csv_name: plot-${random_number}.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True

--- a/templates/overhead_resident_anonymous_memory.txt
+++ b/templates/overhead_resident_anonymous_memory.txt
@@ -14,7 +14,7 @@
   - title: Simple Sub ${rmw_implementation} Resident Anonymous Memory
     description: "The figure shown above shows the resident anonymous memory in Mb used by the subscriber. The publisher is set to <b>${rmw_implementation}</b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Mb
-    master_csv_name: plot-${random_number}1.csv
+    master_csv_name: plot-${random_number}-1.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True

--- a/templates/overhead_sent_packets.txt
+++ b/templates/overhead_sent_packets.txt
@@ -1,7 +1,7 @@
   - title: Simple Pub ${rmw_implementation} Sent packets per second
     description: "The figure shown above shows the sent packets per second. The publisher is set to <b>${rmw_implementation}</b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Packets per second
-    master_csv_name: plot-$random_number.csv
+    master_csv_name: plot-${random_number}.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True

--- a/templates/overhead_virtual_memory.txt
+++ b/templates/overhead_virtual_memory.txt
@@ -18,7 +18,7 @@
     description: "The figure shown above shows the virtual memory in Mb used by the subscriber. The publisher is set to <b>${rmw_implementation}</b> but the subscriber will vary between the avaiables. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode. <br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 5</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Mb
     num_builds: 50
-    master_csv_name: plot-${random_number}1.csv
+    master_csv_name: plot-${random_number}-1.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True

--- a/templates/performance_test_1p_1k.txt
+++ b/templates/performance_test_1p_1k.txt
@@ -16,7 +16,7 @@
   - title: Throughtput
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Mbits/s (mean)
-    master_csv_name: plot-${random_number}1.csv
+    master_csv_name: plot-${random_number}-1.csv
     style: line
     num_builds: 10
     y_axis_minimum: 0
@@ -31,7 +31,7 @@
   - title: Max Resident Set Size
     description: "The figure shown above shows the max resident size Megabytes for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Megabytes
-    master_csv_name: plot-${random_number}2.csv
+    master_csv_name: plot-${random_number}-2.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -44,7 +44,7 @@
   - title: Received packets
     description: "The figure shown above shows the received packets for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}3.csv
+    master_csv_name: plot-${random_number}-3.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -57,7 +57,7 @@
   - title: Sent packets
     description: "The figure shown above shows the sent packets for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}4.csv
+    master_csv_name: plot-${random_number}-4.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -70,7 +70,7 @@
   - title: Lost packets
     description: "The figure shown above shows the lost packets for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}5.csv
+    master_csv_name: plot-${random_number}-5.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -83,7 +83,7 @@
   - title: CPU usage (%)
     description: "The figure shown above shows the cpu usage in % for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}6.csv
+    master_csv_name: plot-${random_number}-6.csv
     style: line
     num_builds: 10
     y_axis_minimum: 0

--- a/templates/performance_test_1p_multi.txt
+++ b/templates/performance_test_1p_multi.txt
@@ -14,7 +14,7 @@
   - title: Average Single-Trip Time (Array4k)
     description: "The figure shown above shows the average single-trip time in millisecond for different DDS vendors using a 4K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4K</li></ul>"
     y_axis_label: Milliseconds
-    master_csv_name: plot-${random_number}1.csv
+    master_csv_name: plot-${random_number}-1.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -27,7 +27,7 @@
   - title: Average Single-Trip Time (Array16k)
     description: "The figure shown above shows the average single-trip time in millisecond for different DDS vendors using a 16K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 16K</li></ul>"
     y_axis_label: Milliseconds
-    master_csv_name: plot-${random_number}2.csv
+    master_csv_name: plot-${random_number}-2.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -40,7 +40,7 @@
   - title: Average Single-Trip Time (Array32k)
     description: "The figure shown above shows the average single-trip time in millisecond for different DDS vendors using a 32K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 32K</li></ul>"
     y_axis_label: Milliseconds
-    master_csv_name: plot-${random_number}3.csv
+    master_csv_name: plot-${random_number}-3.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -53,7 +53,7 @@
   - title: Average Single-Trip Time (Array60k)
     description: "The figure shown above shows the average single-trip time in millisecond for different DDS vendors using a 60K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 60K</li></ul>"
     y_axis_label: Milliseconds
-    master_csv_name: plot-${random_number}4.csv
+    master_csv_name: plot-${random_number}-4.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -66,7 +66,7 @@
   - title: Average Single-Trip Time (PointCloud512k)
     description: "The figure shown above shows the average single-trip time in millisecond for different DDS vendors using a 512K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 512K</li></ul>"
     y_axis_label: Milliseconds
-    master_csv_name: plot-${random_number}5.csv
+    master_csv_name: plot-${random_number}-5.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -79,7 +79,7 @@
   - title: Average Single-Trip Time (Array1m)
     description: "The figure shown above shows the average single-trip time in millisecond for different DDS vendors using a 1M array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1M</li></ul>"
     y_axis_label: Milliseconds
-    master_csv_name: plot-${random_number}6.csv
+    master_csv_name: plot-${random_number}-6.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -92,7 +92,7 @@
   - title: Average Single-Trip Time (Array2m)
     description: "The figure shown above shows the average single-trip time in millisecond for different DDS vendors using a 2M array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 2M</li></ul>"
     y_axis_label: Milliseconds
-    master_csv_name: plot-${random_number}7.csv
+    master_csv_name: plot-${random_number}-7.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -105,7 +105,7 @@
   - title: Average Single-Trip Time (Array4m)
     description: "The figure shown above shows the average single-trip time in milisecond for different DDS vendors using a 4M array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4M</li></ul>"
     y_axis_label: Milliseconds
-    master_csv_name: plot-${random_number}24.csv
+    master_csv_name: plot-${random_number}-24.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -118,7 +118,7 @@
   - title: Average Single-Trip Time (Array8m)
     description: "The figure shown above shows the average single-trip time in milisecond for different DDS vendors using a 8M array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 8M</li></ul>"
     y_axis_label: Milliseconds
-    master_csv_name: plot-${random_number}25.csv
+    master_csv_name: plot-${random_number}-25.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -131,7 +131,7 @@
   - title: Average Single-Trip Time (PointCloud8m)
     description: "The figure shown above shows the average single-trip time in milisecond for different DDS vendors using a 8M point cloud message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 8M</li></ul>"
     y_axis_label: Milliseconds
-    master_csv_name: plot-${random_number}26.csv
+    master_csv_name: plot-${random_number}-26.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -144,7 +144,7 @@
   - title: Throughput (Array1k)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}8.csv
+    master_csv_name: plot-${random_number}-8.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -157,7 +157,7 @@
   - title: Throughput (Array4k)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 4K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4K</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}9.csv
+    master_csv_name: plot-${random_number}-9.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -170,7 +170,7 @@
   - title: Throughput (Array16k)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 16K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 16K</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}10.csv
+    master_csv_name: plot-${random_number}-10.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -183,7 +183,7 @@
   - title: Throughput (Array32k)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 32K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 32K</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}11.csv
+    master_csv_name: plot-${random_number}-11.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -196,7 +196,7 @@
   - title: Throughput (Array60k)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 60K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 60K</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}12.csv
+    master_csv_name: plot-${random_number}-12.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -209,7 +209,7 @@
   - title: Throughput (PointCloud512k)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 512K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 512K</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}13.csv
+    master_csv_name: plot-${random_number}-13.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -222,7 +222,7 @@
   - title: Throughput (Array1m)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 1M array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1M</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}14.csv
+    master_csv_name: plot-${random_number}-14.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -235,7 +235,7 @@
   - title: Throughput (Array2m)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 2M array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 2M</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}15.csv
+    master_csv_name: plot-${random_number}-15.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -248,7 +248,7 @@
   - title: Throughput (Array4m)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 4M array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4M</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}27.csv
+    master_csv_name: plot-${random_number}-27.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -261,7 +261,7 @@
   - title: Throughput (Array8m)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 8M array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 8M</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}28.csv
+    master_csv_name: plot-${random_number}-28.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -274,7 +274,7 @@
   - title: Throughput (PointCloud8m)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 8M point cloud message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 8M</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}29.csv
+    master_csv_name: plot-${random_number}-29.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -287,7 +287,7 @@
   - title: Lost packets  (Array1k)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 1K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}16.csv
+    master_csv_name: plot-${random_number}-16.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -300,7 +300,7 @@
   - title: Lost packets  (Array4k)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 4K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4K</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}17.csv
+    master_csv_name: plot-${random_number}-17.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -313,7 +313,7 @@
   - title: Lost packets  (Array16k)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 16K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 16K</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}18.csv
+    master_csv_name: plot-${random_number}-18.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -326,7 +326,7 @@
   - title: Lost packets  (Array32k)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 32K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 32K</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}19.csv
+    master_csv_name: plot-${random_number}-19.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -339,7 +339,7 @@
   - title: Lost packets  (Array60k)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 64K array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 60K</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}20.csv
+    master_csv_name: plot-${random_number}-20.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -352,7 +352,7 @@
   - title: Lost packets  (PointCloud512k)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 512K point cloud message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 512k</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}21.csv
+    master_csv_name: plot-${random_number}-21.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -365,7 +365,7 @@
   - title: Lost packets  (Array1m)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 1m array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1m</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}22.csv
+    master_csv_name: plot-${random_number}-22.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -378,7 +378,7 @@
   - title: Lost packets  (Array2m)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 2m array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 2m</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}23.csv
+    master_csv_name: plot-${random_number}-23.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -391,7 +391,7 @@
   - title: Lost packets  (Array4m)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 4m array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4m</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}30.csv
+    master_csv_name: plot-${random_number}-30.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -404,7 +404,7 @@
   - title: Lost packets  (Array8m)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 8m array message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 8m</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}31.csv
+    master_csv_name: plot-${random_number}-31.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -417,7 +417,7 @@
   - title: Lost packets  (PointCloud8m)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 8m point cloud message. All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 8m</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}32.csv
+    master_csv_name: plot-${random_number}-32.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True

--- a/templates/performance_test_2p_1k.txt
+++ b/templates/performance_test_2p_1k.txt
@@ -16,7 +16,7 @@
   - title: Throughtput
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1k</li></ul>"
     y_axis_label: Mbits/s (mean)
-    master_csv_name: plot-${random_number}1.csv
+    master_csv_name: plot-${random_number}-1.csv
     style: line
     num_builds: 10
     y_axis_minimum: 0
@@ -31,7 +31,7 @@
   - title: Max Resident Set Size
     description: "The figure shown above shows the max resident set size in Megabytes for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1k</li></ul>"
     y_axis_label: Megabytes
-    master_csv_name: plot-${random_number}2.csv
+    master_csv_name: plot-${random_number}-2.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -44,7 +44,7 @@
   - title: Received packets
     description: "The figure shown above shows the received packets per second for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1k</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}3.csv
+    master_csv_name: plot-${random_number}-3.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -57,7 +57,7 @@
   - title: Sent packets
     description: "The figure shown above shows the sent packets per second for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1k</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}4.csv
+    master_csv_name: plot-${random_number}-4.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -70,7 +70,7 @@
   - title: Lost packets
     description: "The figure shown above shows the total lost packets for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1k</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}5.csv
+    master_csv_name: plot-${random_number}-5.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -83,7 +83,7 @@
   - title: CPU usage (%)
     description: "The figure shown above shows the CPU usage in % for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1k</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}6.csv
+    master_csv_name: plot-${random_number}-6.csv
     style: line
     num_builds: 10
     y_axis_minimum: 0

--- a/templates/performance_test_2p_multi.txt
+++ b/templates/performance_test_2p_multi.txt
@@ -14,7 +14,7 @@
   - title: Average Single-Trip Time (Array4k)
     description: "The figure shown above shows the average single-trip time in millisecond for different DDS vendors using a 4K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 4K</li></ul>"
     y_axis_label: Milliseconds
-    master_csv_name: plot-${random_number}1.csv
+    master_csv_name: plot-${random_number}-1.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -27,7 +27,7 @@
   - title: Average Single-Trip Time (Array16k)
     description: "The figure shown above shows the average single-trip time in millisecond for different DDS vendors using a 16K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 16K</li></ul>"
     y_axis_label: Milliseconds
-    master_csv_name: plot-${random_number}2.csv
+    master_csv_name: plot-${random_number}-2.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -40,7 +40,7 @@
   - title: Average Single-Trip Time (Array32k)
     description: "The figure shown above shows the average single-trip time in millisecond for different DDS vendors using a 32K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 32K</li></ul>"
     y_axis_label: Milliseconds
-    master_csv_name: plot-${random_number}3.csv
+    master_csv_name: plot-${random_number}-3.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -53,7 +53,7 @@
   - title: Average Single-Trip Time (Array60k)
     description: "The figure shown above shows the average single-trip time in millisecond for different DDS vendors using a 60K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 60K</li></ul>"
     y_axis_label: Milliseconds
-    master_csv_name: plot-${random_number}4.csv
+    master_csv_name: plot-${random_number}-4.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -66,7 +66,7 @@
   - title: Average Single-Trip Time (PointCloud512k)
     description: "The figure shown above shows the average single-trip time in milisecond for different DDS vendors using a 512K point cloud message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 512K</li></ul>"
     y_axis_label: Milliseconds
-    master_csv_name: plot-${random_number}5.csv
+    master_csv_name: plot-${random_number}-5.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -79,7 +79,7 @@
   - title: Average Single-Trip Time (Array1m)
     description: "The figure shown above shows the average single-trip time in millisecond for different DDS vendors using a 1M array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 1M</li></ul>"
     y_axis_label: Milliseconds
-    master_csv_name: plot-${random_number}6.csv
+    master_csv_name: plot-${random_number}-6.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -92,7 +92,7 @@
   - title: Average Single-Trip Time (Array2m)
     description: "The figure shown above shows the average single-trip time in millisecond for different DDS vendors using a 2M array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 2M</li></ul>"
     y_axis_label: Milliseconds
-    master_csv_name: plot-${random_number}7.csv
+    master_csv_name: plot-${random_number}-7.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -105,7 +105,7 @@
   - title: Average Single-Trip Time (Array4m)
     description: "The figure shown above shows the average single-trip time in milisecond for different DDS vendors using a 4M array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 4M</li></ul>"
     y_axis_label: Milliseconds
-    master_csv_name: plot-${random_number}24.csv
+    master_csv_name: plot-${random_number}-24.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -118,7 +118,7 @@
   - title: Average Single-Trip Time (Array8m)
     description: "The figure shown above shows the average single-trip time in milisecond for different DDS vendors using a 8M array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 8M</li></ul>"
     y_axis_label: Milliseconds
-    master_csv_name: plot-${random_number}25.csv
+    master_csv_name: plot-${random_number}-25.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -131,7 +131,7 @@
   - title: Average Single-Trip Time (PointCloud8m)
     description: "The figure shown above shows the average single-trip time in milisecond for different DDS vendors using a 8M point cloud message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 2</li><li><b>Message size</b> 8M</li></ul>"
     y_axis_label: Milliseconds
-    master_csv_name: plot-${random_number}26.csv
+    master_csv_name: plot-${random_number}-26.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -144,7 +144,7 @@
   - title: Throughput (Array1k)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}8.csv
+    master_csv_name: plot-${random_number}-8.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -157,7 +157,7 @@
   - title: Throughput (Array4k)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 4K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4K</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}9.csv
+    master_csv_name: plot-${random_number}-9.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -170,7 +170,7 @@
   - title: Throughput (Array16k)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 16K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 16K</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}10.csv
+    master_csv_name: plot-${random_number}-10.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -183,7 +183,7 @@
   - title: Throughput (Array32k)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 32K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 32K</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}11.csv
+    master_csv_name: plot-${random_number}-11.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -196,7 +196,7 @@
   - title: Throughput (Array60k)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 60K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 60K</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}12.csv
+    master_csv_name: plot-${random_number}-12.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -209,7 +209,7 @@
   - title: Throughput (PointCloud512k)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 512K point cloud message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 512K</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}13.csv
+    master_csv_name: plot-${random_number}-13.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -222,7 +222,7 @@
   - title: Throughput (Array1m)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 1M array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1M</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}14.csv
+    master_csv_name: plot-${random_number}-14.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -235,7 +235,7 @@
   - title: Throughput (Array2m)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 2M array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 2M</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}15.csv
+    master_csv_name: plot-${random_number}-15.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -248,7 +248,7 @@
   - title: Throughput (Array4m)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 4M array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4M</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}27.csv
+    master_csv_name: plot-${random_number}-27.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -261,7 +261,7 @@
   - title: Throughput (Array8m)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 8M array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 8M</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}28.csv
+    master_csv_name: plot-${random_number}-28.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -274,7 +274,7 @@
   - title: Throughput (PointCloud8m)
     description: "The figure shown above shows the throughput in Mbits/s for different DDS vendors using a 8M point cloud message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 8M</li></ul>"
     y_axis_label: Mbits/s
-    master_csv_name: plot-${random_number}29.csv
+    master_csv_name: plot-${random_number}-29.csv
     style: line
     num_builds: 10
     exclZero: False
@@ -287,7 +287,7 @@
   - title: Lost packets  (Array1k)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 1K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1K</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}16.csv
+    master_csv_name: plot-${random_number}-16.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -300,7 +300,7 @@
   - title: Lost packets  (Array4k)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 4K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4K</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}17.csv
+    master_csv_name: plot-${random_number}-17.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -313,7 +313,7 @@
   - title: Lost packets  (Array16k)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 16K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 16K</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}18.csv
+    master_csv_name: plot-${random_number}-18.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -326,7 +326,7 @@
   - title: Lost packets  (Array32k)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 32K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 32K</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}19.csv
+    master_csv_name: plot-${random_number}-19.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -339,7 +339,7 @@
   - title: Lost packets  (Array60k)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 64K array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 60K</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}20.csv
+    master_csv_name: plot-${random_number}-20.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -352,7 +352,7 @@
   - title: Lost packets  (PointCloud512k)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 512K point cloud message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 512k</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}21.csv
+    master_csv_name: plot-${random_number}-21.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -365,7 +365,7 @@
   - title: Lost packets  (Array1m)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 1m array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 1m</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}22.csv
+    master_csv_name: plot-${random_number}-22.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -378,7 +378,7 @@
   - title: Lost packets  (Array2m)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 2m array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 2m</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}23.csv
+    master_csv_name: plot-${random_number}-23.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -391,7 +391,7 @@
   - title: Lost packets  (Array4m)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 4m array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 4m</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}30.csv
+    master_csv_name: plot-${random_number}-30.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -404,7 +404,7 @@
   - title: Lost packets  (Array8m)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 8m array message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 8m</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}31.csv
+    master_csv_name: plot-${random_number}-31.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True
@@ -417,7 +417,7 @@
   - title: Lost packets  (PointCloud8m)
     description: "The figure shown above shows the lost packets for different DDS vendors using a 8m point cloud message and two processes (one process to create the publisher and another process for the subscriber). All DDS vendors are configured in asynchronous mode except cycloneDDS which is configured in syncronous mode.<br></br><ul><li><b>QoS</b> Best effort</li><li><b>Rate</b> 1000</li><li><b>Runtime</b> 30 seconds</li><li><b>N process</b> 1</li><li><b>Message size</b> 8m</li></ul>"
     y_axis_label: Number
-    master_csv_name: plot-${random_number}32.csv
+    master_csv_name: plot-${random_number}-32.csv
     style: line
     num_builds: 10
     y_axis_exclude_zero: True


### PR DESCRIPTION
This enables reproducible configuration generation which allows to easier review changes.

The `cvs` filename changes resulting from this were easy to generate from the diff between the current and newly generated config:

<details>

<summary>Rename existing .csv files to match this patch (Rolling and Foxy)</summary>

```
mv plot-5588997305133279978.csv plot-overhead_round_trip_rmw_fastrtps_cpp_async.csv
mv plot-7342549777662720798.csv plot-overhead_round_trip_rmw_fastrtps_cpp_sync.csv
mv plot-8944121117692986193.csv plot-overhead_round_trip_rmw_connext_cpp.csv
mv plot-4925622433814571003.csv plot-overhead_round_trip_rmw_fastrtps_dynamic_cpp.csv
mv plot-5315635346786210138.csv plot-overhead_round_trip_rmw_cyclonedds_cpp.csv
mv plot-4026462062305368271.csv plot-overhead_received_packets_rmw_fastrtps_cpp_async.csv
mv plot-6161528915302832860.csv plot-overhead_received_packets_rmw_fastrtps_cpp_sync.csv
mv plot-0986258857293195110.csv plot-overhead_received_packets_rmw_connext_cpp.csv
mv plot-6919183902367698983.csv plot-overhead_received_packets_rmw_fastrtps_dynamic_cpp.csv
mv plot-3045752545321417686.csv plot-overhead_received_packets_rmw_cyclonedds_cpp.csv
mv plot-5333913382826373319.csv plot-overhead_sent_packets_rmw_fastrtps_cpp_async.csv
mv plot-8894717269710513878.csv plot-overhead_sent_packets_rmw_fastrtps_cpp_sync.csv
mv plot-9646952103853605664.csv plot-overhead_sent_packets_rmw_connext_cpp.csv
mv plot-7353466940017559350.csv plot-overhead_sent_packets_rmw_fastrtps_dynamic_cpp.csv
mv plot-8195191837095292151.csv plot-overhead_sent_packets_rmw_cyclonedds_cpp.csv
mv plot-7981837854803730627.csv plot-overhead_lost_packets_rmw_fastrtps_cpp_async.csv
mv plot-6383649931071772620.csv plot-overhead_lost_packets_rmw_fastrtps_cpp_sync.csv
mv plot-8871536387988854573.csv plot-overhead_lost_packets_rmw_connext_cpp.csv
mv plot-9718556441358614962.csv plot-overhead_lost_packets_rmw_fastrtps_dynamic_cpp.csv
mv plot-9757752890693043211.csv plot-overhead_lost_packets_rmw_cyclonedds_cpp.csv
mv plot-1088747087890303706.csv plot-overhead_virtual_memory_rmw_fastrtps_cpp_async.csv
mv plot-10887470878903037061.csv plot-overhead_virtual_memory_rmw_fastrtps_cpp_async-1.csv
mv plot-3333346581483484299.csv plot-overhead_virtual_memory_rmw_fastrtps_cpp_sync.csv
mv plot-33333465814834842991.csv plot-overhead_virtual_memory_rmw_fastrtps_cpp_sync-1.csv
mv plot-2763163448516527272.csv plot-overhead_virtual_memory_rmw_connext_cpp.csv
mv plot-27631634485165272721.csv plot-overhead_virtual_memory_rmw_connext_cpp-1.csv
mv plot-4811497248441839497.csv plot-overhead_virtual_memory_rmw_fastrtps_dynamic_cpp.csv
mv plot-48114972484418394971.csv plot-overhead_virtual_memory_rmw_fastrtps_dynamic_cpp-1.csv
mv plot-2845137311990710210.csv plot-overhead_virtual_memory_rmw_cyclonedds_cpp.csv
mv plot-34191883759068834911.csv plot-overhead_virtual_memory_rmw_cyclonedds_cpp-1.csv
mv plot-3094839294263291120.csv plot-overhead_resident_anonymous_memory_rmw_fastrtps_cpp_async.csv
mv plot-30948392942632911201.csv plot-overhead_resident_anonymous_memory_rmw_fastrtps_cpp_async-1.csv
mv plot-6251834445326441250.csv plot-overhead_resident_anonymous_memory_rmw_fastrtps_cpp_sync.csv
mv plot-62518344453264412501.csv plot-overhead_resident_anonymous_memory_rmw_fastrtps_cpp_sync-1.csv
mv plot-2004633295343598337.csv plot-overhead_resident_anonymous_memory_rmw_connext_cpp.csv
mv plot-20046332953435983371.csv plot-overhead_resident_anonymous_memory_rmw_connext_cpp-1.csv
mv plot-8040912425920547500.csv plot-overhead_resident_anonymous_memory_rmw_fastrtps_dynamic_cpp.csv
mv plot-80409124259205475001.csv plot-overhead_resident_anonymous_memory_rmw_fastrtps_dynamic_cpp-1.csv
mv plot-8349978008992833795.csv plot-overhead_resident_anonymous_memory_rmw_cyclonedds_cpp.csv
mv plot-83499780089928337951.csv plot-overhead_resident_anonymous_memory_rmw_cyclonedds_cpp-1.csv
mv plot-8179839633518921089.csv plot-overhead_physical_memory_rmw_fastrtps_cpp_async.csv
mv plot-81798396335189210891.csv plot-overhead_physical_memory_rmw_fastrtps_cpp_async-1.csv
mv plot-0862972505240146892.csv plot-overhead_physical_memory_rmw_fastrtps_cpp_sync.csv
mv plot-08629725052401468921.csv plot-overhead_physical_memory_rmw_fastrtps_cpp_sync-1.csv
mv plot-0635416978085352022.csv plot-overhead_physical_memory_rmw_connext_cpp.csv
mv plot-06354169780853520221.csv plot-overhead_physical_memory_rmw_connext_cpp-1.csv
mv plot-0383216202598326023.csv plot-overhead_physical_memory_rmw_fastrtps_dynamic_cpp.csv
mv plot-03832162025983260231.csv plot-overhead_physical_memory_rmw_fastrtps_dynamic_cpp-1.csv
mv plot-2138576818485825076.csv plot-overhead_physical_memory_rmw_cyclonedds_cpp.csv
mv plot-21385768184858250761.csv plot-overhead_physical_memory_rmw_cyclonedds_cpp-1.csv
mv plot-2763431561192783410.csv plot-node_spinning.csv
mv plot-27634315611927834101.csv plot-node_spinning-1.csv
mv plot-27634315611927834102.csv plot-node_spinning-2.csv
mv plot-27634315611927834103.csv plot-node_spinning-3.csv
mv plot-8157902422284552762.csv plot-performance_test_1p_1k.csv
mv plot-81579024222845527621.csv plot-performance_test_1p_1k-1.csv
mv plot-81579024222845527622.csv plot-performance_test_1p_1k-2.csv
mv plot-81579024222845527623.csv plot-performance_test_1p_1k-3.csv
mv plot-81579024222845527624.csv plot-performance_test_1p_1k-4.csv
mv plot-81579024222845527625.csv plot-performance_test_1p_1k-5.csv
mv plot-81579024222845527626.csv plot-performance_test_1p_1k-6.csv
mv plot-4496341387413317491.csv plot-performance_test_1p_multi.csv
mv plot-44963413874133174911.csv plot-performance_test_1p_multi-1.csv
mv plot-44963413874133174912.csv plot-performance_test_1p_multi-2.csv
mv plot-44963413874133174913.csv plot-performance_test_1p_multi-3.csv
mv plot-44963413874133174914.csv plot-performance_test_1p_multi-4.csv
mv plot-44963413874133174915.csv plot-performance_test_1p_multi-5.csv
mv plot-44963413874133174916.csv plot-performance_test_1p_multi-6.csv
mv plot-44963413874133174917.csv plot-performance_test_1p_multi-7.csv
mv plot-193943188976495959724.csv plot-performance_test_1p_multi-24.csv
mv plot-193943188976495959725.csv plot-performance_test_1p_multi-25.csv
mv plot-193943188976495959726.csv plot-performance_test_1p_multi-26.csv
mv plot-44963413874133174918.csv plot-performance_test_1p_multi-8.csv
mv plot-44963413874133174919.csv plot-performance_test_1p_multi-9.csv
mv plot-449634138741331749110.csv plot-performance_test_1p_multi-10.csv
mv plot-449634138741331749111.csv plot-performance_test_1p_multi-11.csv
mv plot-449634138741331749112.csv plot-performance_test_1p_multi-12.csv
mv plot-449634138741331749113.csv plot-performance_test_1p_multi-13.csv
mv plot-449634138741331749114.csv plot-performance_test_1p_multi-14.csv
mv plot-449634138741331749115.csv plot-performance_test_1p_multi-15.csv
mv plot-193943188976495959727.csv plot-performance_test_1p_multi-27.csv
mv plot-193943188976495959728.csv plot-performance_test_1p_multi-28.csv
mv plot-193943188976495959729.csv plot-performance_test_1p_multi-29.csv
mv plot-193943188976495959716.csv plot-performance_test_1p_multi-16.csv
mv plot-193943188976495959717.csv plot-performance_test_1p_multi-17.csv
mv plot-193943188976495959718.csv plot-performance_test_1p_multi-18.csv
mv plot-193943188976495959719.csv plot-performance_test_1p_multi-19.csv
mv plot-193943188976495959720.csv plot-performance_test_1p_multi-20.csv
mv plot-193943188976495959721.csv plot-performance_test_1p_multi-21.csv
mv plot-193943188976495959722.csv plot-performance_test_1p_multi-22.csv
mv plot-193943188976495959723.csv plot-performance_test_1p_multi-23.csv
mv plot-193943188976495959730.csv plot-performance_test_1p_multi-30.csv
mv plot-193943188976495959731.csv plot-performance_test_1p_multi-31.csv
mv plot-193943188976495959732.csv plot-performance_test_1p_multi-32.csv
mv plot-2373945274805283737.csv plot-performance_test_2p_1k.csv
mv plot-23739452748052837371.csv plot-performance_test_2p_1k-1.csv
mv plot-23739452748052837372.csv plot-performance_test_2p_1k-2.csv
mv plot-23739452748052837373.csv plot-performance_test_2p_1k-3.csv
mv plot-23739452748052837374.csv plot-performance_test_2p_1k-4.csv
mv plot-23739452748052837375.csv plot-performance_test_2p_1k-5.csv
mv plot-23739452748052837376.csv plot-performance_test_2p_1k-6.csv
mv plot-7458267098136490401.csv plot-performance_test_2p_multi.csv
mv plot-74582670981364904011.csv plot-performance_test_2p_multi-1.csv
mv plot-74582670981364904012.csv plot-performance_test_2p_multi-2.csv
mv plot-74582670981364904013.csv plot-performance_test_2p_multi-3.csv
mv plot-74582670981364904014.csv plot-performance_test_2p_multi-4.csv
mv plot-74582670981364904015.csv plot-performance_test_2p_multi-5.csv
mv plot-74582670981364904016.csv plot-performance_test_2p_multi-6.csv
mv plot-74582670981364904017.csv plot-performance_test_2p_multi-7.csv
mv plot-765160731177728028524.csv plot-performance_test_2p_multi-24.csv
mv plot-765160731177728028525.csv plot-performance_test_2p_multi-25.csv
mv plot-765160731177728028526.csv plot-performance_test_2p_multi-26.csv
mv plot-74582670981364904018.csv plot-performance_test_2p_multi-8.csv
mv plot-74582670981364904019.csv plot-performance_test_2p_multi-9.csv
mv plot-745826709813649040110.csv plot-performance_test_2p_multi-10.csv
mv plot-745826709813649040111.csv plot-performance_test_2p_multi-11.csv
mv plot-745826709813649040112.csv plot-performance_test_2p_multi-12.csv
mv plot-745826709813649040113.csv plot-performance_test_2p_multi-13.csv
mv plot-745826709813649040114.csv plot-performance_test_2p_multi-14.csv
mv plot-745826709813649040115.csv plot-performance_test_2p_multi-15.csv
mv plot-765160731177728028527.csv plot-performance_test_2p_multi-27.csv
mv plot-765160731177728028528.csv plot-performance_test_2p_multi-28.csv
mv plot-765160731177728028529.csv plot-performance_test_2p_multi-29.csv
mv plot-765160731177728028516.csv plot-performance_test_2p_multi-16.csv
mv plot-765160731177728028517.csv plot-performance_test_2p_multi-17.csv
mv plot-765160731177728028518.csv plot-performance_test_2p_multi-18.csv
mv plot-765160731177728028519.csv plot-performance_test_2p_multi-19.csv
mv plot-765160731177728028520.csv plot-performance_test_2p_multi-20.csv
mv plot-765160731177728028521.csv plot-performance_test_2p_multi-21.csv
mv plot-765160731177728028522.csv plot-performance_test_2p_multi-22.csv
mv plot-765160731177728028523.csv plot-performance_test_2p_multi-23.csv
mv plot-765160731177728028530.csv plot-performance_test_2p_multi-30.csv
mv plot-765160731177728028531.csv plot-performance_test_2p_multi-31.csv
mv plot-765160731177728028532.csv plot-performance_test_2p_multi-32.csv
```

</details>