### PR TITLE
reduce the y_axis_maximum for throughput of 1k

### DIFF
--- a/templates/performance_test_1p_1k.txt
+++ b/templates/performance_test_1p_1k.txt
@@ -20,7 +20,7 @@
     style: line
     num_builds: 10
     y_axis_minimum: 0
-    y_axis_maximum: 1000
+    y_axis_maximum: 1.05
     y_axis_exclude_zero: False
     data_series:
     - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1k.csv

--- a/templates/performance_test_2p_1k.txt
+++ b/templates/performance_test_2p_1k.txt
@@ -20,7 +20,7 @@
     style: line
     num_builds: 10
     y_axis_minimum: 0
-    y_axis_maximum: 1000
+    y_axis_maximum: 1.05
     y_axis_exclude_zero: False
     data_series:
     - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1k.csv


### PR DESCRIPTION
The last graph on these two pages shows the throughput for 1000 1k messages in Mbit which is always below 1 Mbit:
* http://build.ros2.org/view/Rci/job/Rci__nightly-performance_ubuntu_focal_amd64/plot/Performance%20One%20Process%20Test%20Results%20(Array1k)/
* http://build.ros2.org/view/Rci/job/Rci__nightly-performance_ubuntu_focal_amd64/plot/Performance%20Two%20Processes%20Test%20Results%20(Array1k)/

The current y-axis max of 1000 Mbit makes the lines all render on top of the x-axis without showing any variation. This patch reduced the y-axis max to 1.05 (to leave a bit of head room in case any value goes above 1.0) to render the values in a way that the actual values can be seen.