### PR TITLE
Revert "reduce the y_axis_maximum for throughput of 1k"

### DIFF
--- a/templates/performance_test_1p_1k.txt
+++ b/templates/performance_test_1p_1k.txt
@@ -20,7 +20,7 @@
     style: line
     num_builds: 10
     y_axis_minimum: 0
-    y_axis_maximum: 1.05
+    y_axis_maximum: 1000
     y_axis_exclude_zero: False
     data_series:
     - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1k.csv

--- a/templates/performance_test_2p_1k.txt
+++ b/templates/performance_test_2p_1k.txt
@@ -20,7 +20,7 @@
     style: line
     num_builds: 10
     y_axis_minimum: 0
-    y_axis_maximum: 1.05
+    y_axis_maximum: 1000
     y_axis_exclude_zero: False
     data_series:
     - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1k.csv


### PR DESCRIPTION
Reverts ros2/buildfarm_perf_tests#78 since it had no effect on the generate plot.

See ros2/ros_buildfarm_config#126 for a different attempt.