### PR TITLE
always use keep_last / depth 10

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -76,11 +76,6 @@ set(PERF_TEST_SKIP_rmw_opensplice_cpp_sync ON
 set(PERF_TEST_SKIP_rmw_connext_cpp_sync ON
   CACHE BOOL "Skip rmw_connext_cpp sync tests")
 
-foreach(large_data_topic Array4m Array8m PointCloud8m)
-  set(PERF_TEST_KEEP_LAST_${large_data_topic} ON
-    CACHE BOOL "Use keep last, depth 10 history in ${large_data_topic} tests")
-endforeach()
-
 # Fast-RTPS ros2-eloquent branch (1.9.3 + bugfixes) does not support synchronous
 # sending of fragments. This means that in that branch, topics Array1m,
 # Array2m, Array4m, Array8m, PointCloud512k, PointCloud8m cannot be sent synchronously in

--- a/test/add_performance_tests.cmake
+++ b/test/add_performance_tests.cmake
@@ -80,13 +80,6 @@ function(add_performance_test
     set(TEST_ENV_TOPIC ${TEST_ENV})
     list(APPEND TEST_ENV_TOPIC ${PERF_TEST_ENV_${TEST_NAME_SYNC_TOPIC}})
 
-    set(KEEP_LAST FALSE)
-    set(HISTORY_DEPTH "")
-    if("${PERF_TEST_KEEP_LAST_${PERF_TEST_TOPIC}}")
-      set(KEEP_LAST TRUE)
-      set(HISTORY_DEPTH 10)
-    endif()
-
     set(NUMBER_PROCESS "1")
 
     get_filename_component(

--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -137,13 +137,11 @@ def generate_test_description(ready_fn):
         '-t', '@PERF_TEST_TOPIC@',
         '--max_runtime', '@PERF_TEST_RUNTIME@',
         '--ignore', '3',
+        '--keep_last',
+        '--history_depth', '10',
     ] + ([
         '--disable-async',
-    ] if '@SYNC_MODE@' == 'sync' and '@COMM@' != 'ROS2' else []) + ([
-        '--keep_last',
-    ] if '@KEEP_LAST@' == 'TRUE' else []) + ([
-        '--history_depth', '@HISTORY_DEPTH@',
-    ] if '@HISTORY_DEPTH@' != '' else [])
+    ] if '@SYNC_MODE@' == 'sync' and '@COMM@' != 'ROS2' else [])
 
     nodes = []
 


### PR DESCRIPTION
Instead of `KEEP_ALL` for non-large messages.