### PR TITLE
Only assert RMW_IMPLEMENTATION when it is used

### DIFF
--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -122,7 +122,8 @@ def _raw_to_png(dataframe, png_path):
 def generate_test_description(ready_fn):
     expected_rmw_implementation = '@RMW_IMPLEMENTATION@'
     rmw_implementation_identifier = get_rmw_implementation_identifier()
-    assert '@COMM@' != 'ROS2' or rmw_implementation_identifier == expected_rmw_implementation, \
+    assert '@COMM@' != 'ROS2' or \
+        rmw_implementation_identifier == expected_rmw_implementation, \
         f'{rmw_implementation_identifier} != {expected_rmw_implementation}'
 
     performance_log_prefix = tempfile.mkstemp(

--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -122,7 +122,7 @@ def _raw_to_png(dataframe, png_path):
 def generate_test_description(ready_fn):
     expected_rmw_implementation = '@RMW_IMPLEMENTATION@'
     rmw_implementation_identifier = get_rmw_implementation_identifier()
-    assert rmw_implementation_identifier == expected_rmw_implementation, \
+    assert '@COMM@' != 'ROS2' or rmw_implementation_identifier == expected_rmw_implementation, \
         f'{rmw_implementation_identifier} != {expected_rmw_implementation}'
 
     performance_log_prefix = tempfile.mkstemp(

--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -120,11 +120,11 @@ def _raw_to_png(dataframe, png_path):
 
 @launch_testing.markers.keep_alive
 def generate_test_description(ready_fn):
-    expected_rmw_implementation = '@RMW_IMPLEMENTATION@'
-    rmw_implementation_identifier = get_rmw_implementation_identifier()
-    assert '@COMM@' != 'ROS2' or \
-        rmw_implementation_identifier == expected_rmw_implementation, \
-        f'{rmw_implementation_identifier} != {expected_rmw_implementation}'
+    if '@COMM@' == 'ROS2':
+        expected_rmw_implementation = '@RMW_IMPLEMENTATION@'
+        rmw_implementation_identifier = get_rmw_implementation_identifier()
+        assert rmw_implementation_identifier == expected_rmw_implementation, \
+            f'{rmw_implementation_identifier} != {expected_rmw_implementation}'
 
     performance_log_prefix = tempfile.mkstemp(
         prefix='performance_test_@TEST_NAME@_', text=True)[1]


### PR DESCRIPTION
When COMM isn't set to 'ROS2', perf_test is operating in standalone DDS mode and doesn't use ROS 2, and is therefore unaffected by the RMW_IMPLEMENTATION variable. In this circumstance, the environment variable isn't set and shouldn't be asserted.

Follow-up to #80