### PR TITLE
Write result files compatible with Jenkins benchmark plugin

### DIFF
--- a/buildfarm_perf_tests/test_results.py
+++ b/buildfarm_perf_tests/test_results.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 from pandas import read_csv
 
 
@@ -51,3 +52,25 @@ def write_jenkins_plot_csv(csv_path, column_name, values):
     with open(csv_path, 'w') as csv:
         csv.write(','.join([column_name] * len(values)) + '\n')
         csv.write(','.join([str(v) for v in values]) + '\n')
+
+
+def write_jenkins_benchmark_json(json_path, sub_group, values):
+    """
+    Write some values to a JSON file for the Jenkins benchmark plugin to use.
+
+    Parameters
+    ----------
+    json_path : str
+        Path to where the *.json file should be written to.
+    sub_group : str
+        Optional supplementary identifier for the test group name.
+    values : dict
+        Mapping from measurement name to benchmark result to be written to the file.
+
+    """
+    group_name = 'buildfarm_perf_tests.' + sub_group
+    out_data = {
+        group_name: values,
+    }
+    with open(json_path, 'w') as json_file:
+        json.dump(out_data, json_file)

--- a/buildfarm_perf_tests/test_results.py
+++ b/buildfarm_perf_tests/test_results.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+
 from pandas import read_csv
 
 

--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -9,6 +9,7 @@ import unittest
 
 from buildfarm_perf_tests.launch import assert_wait_for_successful_exit
 from buildfarm_perf_tests.test_results import read_performance_test_csv
+from buildfarm_perf_tests.test_results import write_jenkins_benchmark_json
 from buildfarm_perf_tests.test_results import write_jenkins_plot_csv
 from launch import LaunchDescription
 from launch.actions import OpaqueFunction
@@ -33,13 +34,13 @@ def _cleanUpLogs(log_pattern):
         os.remove(log)
 
 
-def _raw_to_csv(dataframe, csv_path):
+def _raw_to_jenkins(dataframe, csv_path):
     """
-    Convert from the raw csv data to the csv for the Jenkins plot plugin.
+    Convert from the raw csv data to formats consumble by Jenkins plugins.
 
-    Do not change the order of the columns. The plot plugin indexes into the
-    csv using the column number instead of the column name, because we're
-    using the columns to identify which test produced the data.
+    Do not change the order of the columns in the csv file. The plot plugin
+    indexes into the csv using the column number instead of the column name,
+    because we're using the columns to identify which test produced the data.
 
     Changing the column names here will change the name of the line that
     appears on the plot.
@@ -63,6 +64,56 @@ def _raw_to_csv(dataframe, csv_path):
     ]
 
     write_jenkins_plot_csv(csv_path, '@TEST_NAME@_@PERF_TEST_TOPIC@', values)
+
+    json_path = os.path.splitext(csv_path)[0] + '.benchmark.json'
+    json_values = {
+        'parameters': {
+            'runtime': {
+                'value': @PERF_TEST_RUNTIME@,
+                'unit': 's',
+            },
+            'process_count': {
+                'value': @NUMBER_PROCESS@,
+            },
+            'message_type': {
+                'value': '@PERF_TEST_TOPIC@',
+            },
+        },
+        'average_single_trip_time': {
+            'dblValue': values[0],
+            'unit': 'ms',
+        },
+        'throughput': {
+            'dblValue': values[10],
+            'unit': 'Mbit/s',
+        },
+        'max_resident_set_size': {
+            'dblValue': values[3],
+            'unit': 'MB',
+        },
+        'received_messages': {
+            'value': values[4],
+        },
+        'sent_messages': {
+            'value': values[5],
+        },
+        'lost_messages': {
+            'value': values[6],
+        },
+        'cpu_usage': {
+            'dblValue': values[8],
+            'unit': 'percent',
+        },
+    }
+
+    group_name = 'performance'
+    if '@NUMBER_PROCESS@' == '2':
+        group_name += '_two_process'
+
+    write_jenkins_benchmark_json(
+        json_path,
+        group_name + '.@TEST_NAME@_@PERF_TEST_TOPIC@',
+        json_values)
 
 
 def _raw_to_png(dataframe, png_path):
@@ -197,7 +248,7 @@ class PerformanceTestResults(unittest.TestCase):
             performance_logs = glob(performance_log_prefix + '*')
             assert len(performance_logs) == 1
             performance_data = read_performance_test_csv(performance_logs[0])
-            _raw_to_csv(performance_data, results_base_path + '.csv')
+            _raw_to_jenkins(performance_data, results_base_path + '.csv')
             _raw_to_png(performance_data, results_base_path + '.png')
         else:
             print(

--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -69,11 +69,11 @@ def _raw_to_jenkins(dataframe, csv_path):
     json_values = {
         'parameters': {
             'runtime': {
-                'value': @PERF_TEST_RUNTIME@,
+                'value': '@PERF_TEST_RUNTIME@',
                 'unit': 's',
             },
             'process_count': {
-                'value': @NUMBER_PROCESS@,
+                'value': '@NUMBER_PROCESS@',
             },
             'message_type': {
                 'value': '@PERF_TEST_TOPIC@',
@@ -92,13 +92,13 @@ def _raw_to_jenkins(dataframe, csv_path):
             'unit': 'MB',
         },
         'received_messages': {
-            'value': values[4],
+            'dblValue': values[4],
         },
         'sent_messages': {
-            'value': values[5],
+            'dblValue': values[5],
         },
         'lost_messages': {
-            'value': values[6],
+            'intValue': values[6],
         },
         'cpu_usage': {
             'dblValue': values[8],
@@ -106,14 +106,14 @@ def _raw_to_jenkins(dataframe, csv_path):
         },
     }
 
-    group_name = 'performance'
+    group_name = 'buildfarm_perf_tests.performance'
     if '@NUMBER_PROCESS@' == '2':
         group_name += '_two_process'
 
     write_jenkins_benchmark_json(
         json_path,
-        group_name + '.@TEST_NAME@_@PERF_TEST_TOPIC@',
-        json_values)
+        group_name,
+        {'@TEST_NAME@_@PERF_TEST_TOPIC@': json_values})
 
 
 def _raw_to_png(dataframe, png_path):

--- a/test/test_pub_sub.py.in
+++ b/test/test_pub_sub.py.in
@@ -108,14 +108,14 @@ def _raw_to_jenkins(dataframe, dataframe_perf, csv_path, mode):
     if mode == 'pub':
         json_values.update({
             'lost_messages': {
-                'dblValue': values[18],
+                'intValue': values[18],
             },
             'received_messages': {
                 'dblValue': values[16],
                 'unit': 'msg/s',
             },
             'sent_messages': {
-                'intValue': values[17],
+                'dblValue': values[17],
                 'unit': 'msg/s',
             },
             'average_round_trip_time': {

--- a/test/test_pub_sub.py.in
+++ b/test/test_pub_sub.py.in
@@ -77,11 +77,11 @@ def _raw_to_jenkins(dataframe, dataframe_perf, csv_path, mode):
     json_values = {
         'parameters': {
             'runtime': {
-                'value': @PERF_TEST_RUNTIME@,
+                'value': '@PERF_TEST_RUNTIME@',
                 'unit': 's',
             },
             'process_count': {
-                'value': 2,
+                'value': '2',
             },
             'message_type': {
                 'value': '@PERF_TEST_TOPIC@',
@@ -108,26 +108,26 @@ def _raw_to_jenkins(dataframe, dataframe_perf, csv_path, mode):
     if mode == 'pub':
         json_values.update({
             'lost_messages': {
-                'value': values[18],
+                'dblValue': values[18],
             },
             'received_messages': {
-                'value': values[16],
+                'dblValue': values[16],
                 'unit': 'msg/s',
             },
             'sent_messages': {
-                'value': values[17],
+                'intValue': values[17],
                 'unit': 'msg/s',
             },
             'average_round_trip_time': {
-                'value': values[14],
+                'dblValue': values[14],
                 'unit': 'ms',
             },
         })
 
     write_jenkins_benchmark_json(
         json_path,
-        'pub_sub.Publisher-@TEST_NAME@_Subscriber-@RMW_IMPLEMENTATION_SUB@',
-        json_values)
+        'buildfarm_perf_tests.pub_sub',
+        {'Publisher-@TEST_NAME@_Subscriber-@RMW_IMPLEMENTATION_SUB@': json_values})
 
 
 def _raw_to_png(dataframe, dataframe_perf, png_path, mode, rmw_impl):

--- a/test/test_pub_sub.py.in
+++ b/test/test_pub_sub.py.in
@@ -10,6 +10,7 @@ import unittest
 from buildfarm_perf_tests.launch import assert_wait_for_successful_exit
 from buildfarm_perf_tests.launch import SystemMetricCollector
 from buildfarm_perf_tests.test_results import read_performance_test_csv
+from buildfarm_perf_tests.test_results import write_jenkins_benchmark_json
 from buildfarm_perf_tests.test_results import write_jenkins_plot_csv
 from launch import LaunchDescription
 from launch.actions import OpaqueFunction
@@ -29,13 +30,13 @@ def _cleanUpLogs(log_pattern):
         os.remove(log)
 
 
-def _raw_to_csv(dataframe, dataframe_perf, csv_path, mode):
+def _raw_to_jenkins(dataframe, dataframe_perf, csv_path, mode):
     """
-    Convert from the raw csv data to the csv for the Jenkins plot plugin.
+    Convert from the raw csv data to formats consumble by Jenkins plugins.
 
-    Do not change the order of the columns. The plot plugin indexes into the
-    csv using the column number instead of the column name, because we're
-    using the columns to identify which test produced the data.
+    Do not change the order of the columns in the csv file. The plot plugin
+    indexes into the csv using the column number instead of the column name,
+    because we're using the columns to identify which test produced the data.
 
     Changing the column names here will change the name of the line that
     appears on the plot.
@@ -67,9 +68,66 @@ def _raw_to_csv(dataframe, dataframe_perf, csv_path, mode):
         dataframe_agg.loc['mean', 'system virtual memory (Mb)'],
     ]
 
+    full_csv_path = '%s_%s.csv' % (csv_path[:-4], mode)
     write_jenkins_plot_csv(
-        '%s_%s.csv' % (csv_path[:-4], mode),
+        full_csv_path,
         'Publisher-@TEST_NAME@_Subscriber-@RMW_IMPLEMENTATION_SUB@', values)
+
+    json_path = os.path.splitext(full_csv_path)[0] + '.benchmark.json'
+    json_values = {
+        'parameters': {
+            'runtime': {
+                'value': @PERF_TEST_RUNTIME@,
+                'unit': 's',
+            },
+            'process_count': {
+                'value': 2,
+            },
+            'message_type': {
+                'value': '@PERF_TEST_TOPIC@',
+            },
+        },
+        'cpu_usage_' + mode: {
+            'dblValue': values[5],
+            'unit': 'percent',
+        },
+        'memory_physical_' + mode: {
+            'dblValue': values[8],
+            'unit': 'MB',
+        },
+        'resident_anonymous_memory_' + mode: {
+            'dblValue': values[11],
+            'unit': 'MB',
+        },
+        'virtual_memory_' + mode: {
+            'dblValue': values[2],
+            'unit': 'MB',
+        },
+    }
+
+    if mode == 'pub':
+        json_values.update({
+            'lost_messages': {
+                'value': values[18],
+            },
+            'received_messages': {
+                'value': values[16],
+                'unit': 'msg/s',
+            },
+            'sent_messages': {
+                'value': values[17],
+                'unit': 'msg/s',
+            },
+            'average_round_trip_time': {
+                'value': values[14],
+                'unit': 'ms',
+            },
+        })
+
+    write_jenkins_benchmark_json(
+        json_path,
+        'pub_sub.Publisher-@TEST_NAME@_Subscriber-@RMW_IMPLEMENTATION_SUB@',
+        json_values)
 
 
 def _raw_to_png(dataframe, dataframe_perf, png_path, mode, rmw_impl):
@@ -230,7 +288,7 @@ class PerformanceTestResults(unittest.TestCase):
             performance_data = read_performance_test_csv(performance_logs[0])
             performance_data_cpumem = read_performance_test_csv(
                 performance_log_cpumem_pub, start_marker=None)
-            _raw_to_csv(
+            _raw_to_jenkins(
                 performance_data_cpumem, performance_data,
                 results_base_path + '.csv', 'pub')
             if performance_overhead_png:
@@ -243,7 +301,7 @@ class PerformanceTestResults(unittest.TestCase):
             performance_data = read_performance_test_csv(performance_logs[0])
             performance_data_cpumem = read_performance_test_csv(
                 performance_log_cpumem_sub, start_marker=None)
-            _raw_to_csv(
+            _raw_to_jenkins(
                 performance_data_cpumem, performance_data,
                 results_base_path + '.csv', 'sub')
             if performance_overhead_png:

--- a/test/test_spinning.py.in
+++ b/test/test_spinning.py.in
@@ -10,6 +10,7 @@ import unittest
 from buildfarm_perf_tests.launch import assert_wait_for_successful_exit
 from buildfarm_perf_tests.launch import SystemMetricCollector
 from buildfarm_perf_tests.test_results import read_performance_test_csv
+from buildfarm_perf_tests.test_results import write_jenkins_benchmark_json
 from buildfarm_perf_tests.test_results import write_jenkins_plot_csv
 from launch import LaunchDescription
 from launch.actions import EmitEvent
@@ -35,13 +36,13 @@ def _cleanUpLogs(log_pattern):
         os.remove(log)
 
 
-def _raw_to_csv(dataframe, csv_path):
+def _raw_to_jenkins(dataframe, csv_path):
     """
-    Convert from the raw csv data to the csv for the Jenkins plot plugin.
+    Convert from the raw csv data to formats consumble by Jenkins plugins.
 
-    Do not change the order of the columns. The plot plugin indexes into the
-    csv using the column number instead of the column name, because we're
-    using the columns to identify which test produced the data.
+    Do not change the order of the columns in the csv file. The plot plugin
+    indexes into the csv using the column number instead of the column name,
+    because we're using the columns to identify which test produced the data.
 
     Changing the column names here will change the name of the line that
     appears on the plot.
@@ -64,6 +65,40 @@ def _raw_to_csv(dataframe, csv_path):
     ]
 
     write_jenkins_plot_csv(csv_path, '@TEST_NAME@', values)
+
+    json_path = os.path.splitext(csv_path)[0] + '.benchmark.json'
+    json_values = {
+        'parameters': {
+            'runtime': {
+                'value': @PERF_TEST_RUNTIME@,
+                'unit': 's',
+            },
+            'process_count': {
+                'value': 1,
+            },
+        },
+        'virtual_memory': {
+            'dblValue': values[2],
+            'unit': 'MB',
+        },
+        'cpu_usage': {
+            'dblValue': values[5],
+            'unit': 'percent',
+        },
+        'physical_memory': {
+            'dblValue': values[8],
+            'unit': 'MB',
+        },
+        'resident_anonymous_memory': {
+            'dblValue': values[11],
+            'unit': 'MB',
+        },
+    }
+
+    write_jenkins_benchmark_json(
+        json_path,
+        'spinning.@TEST_NAME@',
+        json_values)
 
 
 def _raw_to_png(dataframe, png_path):
@@ -140,7 +175,7 @@ class NodeSpinningTestResults(unittest.TestCase):
         if results_base_path:
             performance_data_cpumem = read_performance_test_csv(
                 performance_log_cpumem, start_marker=None)
-            _raw_to_csv(performance_data_cpumem, results_base_path + '.csv')
+            _raw_to_jenkins(performance_data_cpumem, results_base_path + '.csv')
             _raw_to_png(performance_data_cpumem, results_base_path + '.png')
         else:
             print(

--- a/test/test_spinning.py.in
+++ b/test/test_spinning.py.in
@@ -70,11 +70,11 @@ def _raw_to_jenkins(dataframe, csv_path):
     json_values = {
         'parameters': {
             'runtime': {
-                'value': @PERF_TEST_RUNTIME@,
+                'value': '@PERF_TEST_RUNTIME@',
                 'unit': 's',
             },
             'process_count': {
-                'value': 1,
+                'value': '1',
             },
         },
         'virtual_memory': {
@@ -97,8 +97,8 @@ def _raw_to_jenkins(dataframe, csv_path):
 
     write_jenkins_benchmark_json(
         json_path,
-        'spinning.@TEST_NAME@',
-        json_values)
+        'buildfarm_perf_tests.spinning',
+        {'@TEST_NAME@': json_values})
 
 
 def _raw_to_png(dataframe, png_path):


### PR DESCRIPTION
This change adds result files that can be consumed by the Jenkins benchmark plugin. All of the metrics currently available through the Jenkins plot plugin are exposed here.

Once these statistics have settled, we can enable thresholds to receive build failures when the metrics deviate significantly.