### PR TITLE
Use new argument names for launch_ros

### DIFF
--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -201,7 +201,7 @@ def generate_test_description(ready_fn):
         # Publisher node. It has 0 subscribers
         node_pub = Node(
           package='performance_test',
-          node_executable='perf_test',
+          executable='perf_test',
           output='log',
           arguments=arguments + [
               '-s', '0',
@@ -220,7 +220,7 @@ def generate_test_description(ready_fn):
     #   - 2 processes: The node only has a subscriber
     node_under_test = Node(
         package='performance_test',
-        node_executable='perf_test',
+        executable='perf_test',
         output='log',
         arguments=arguments + [
             '-l', performance_log_prefix,

--- a/test/test_pub_sub.py.in
+++ b/test/test_pub_sub.py.in
@@ -213,7 +213,7 @@ def generate_test_description(ready_fn):
     os.remove(performance_log_prefix_sub)
 
     node_main_test = Node(
-        package='performance_test', node_executable='perf_test', output='log',
+        package='performance_test', executable='perf_test', output='log',
         arguments=[
             '-c', 'ROS2',
             '-t', '@PERF_TEST_TOPIC@',
@@ -233,7 +233,7 @@ def generate_test_description(ready_fn):
         timeout=int(@PERF_TEST_RUNTIME@ / (1 / 1.5)))
 
     node_relay_test = Node(
-        package='performance_test', node_executable='perf_test', output='log',
+        package='performance_test', executable='perf_test', output='log',
         arguments=[
             '-c', 'ROS2',
             '-t', '@PERF_TEST_TOPIC@',

--- a/test/test_spinning.py.in
+++ b/test/test_spinning.py.in
@@ -134,7 +134,7 @@ def generate_test_description(ready_fn):
 
     node_spinning_test = Node(
         package='buildfarm_perf_tests',
-        node_executable='node_spinning',
+        executable='node_spinning',
         output='log',
     )
     node_spinning_timer = RegisterEventHandler(OnProcessStart(


### PR DESCRIPTION
These new names were introduced in Foxy, at which time the old argument names were deprecated. That means that this change is only compatible with Foxy and newer.

To deal with that, I created an `eloquent` branch and will re-target the Eloquent nightly job to use that branch.