### PR TITLE
Use new argument names for launch_ros (Part 2)

### DIFF
--- a/buildfarm_perf_tests/launch.py
+++ b/buildfarm_perf_tests/launch.py
@@ -60,7 +60,7 @@ class SystemMetricCollector(Node):
         # because we implicitly set them right here.
         assert 'arguments' not in kwargs
         assert 'package' not in kwargs
-        assert 'node_executable' not in kwargs
+        assert 'executable' not in kwargs
         assert 'executable' not in kwargs
 
         self.__pid_var_name = '__PROCESS_ID_%d' % id(self)

--- a/buildfarm_perf_tests/launch.py
+++ b/buildfarm_perf_tests/launch.py
@@ -66,7 +66,7 @@ class SystemMetricCollector(Node):
         self.__pid_var_name = '__PROCESS_ID_%d' % id(self)
 
         kwargs['package'] = 'buildfarm_perf_tests'
-        kwargs['node_executable'] = 'system_metric_collector'
+        kwargs['executable'] = 'system_metric_collector'
         kwargs['arguments'] = [
             '--log', log_file,
             '--process_pid', LocalSubstitution(self.__pid_var_name)]


### PR DESCRIPTION
Follow-up to #89

I missed this usage.

Signed-off-by: Scott K Logan <logans@cottsay.net>