### PR TITLE
Hotfix in Readme.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Again we plot measurement:
 ### Run
 
 ```bash
-colcon test --packages-select buildfarm_perf_tests -DPERF_TEST_MAX_RUNTIME="30" -DPERF_TEST_TOPIC="Array1k" --event-handlers console_direct+
+colcon test --packages-select buildfarm_perf_tests --event-handlers console_direct+
 ```
 
 Add at the end the flags `--event-handlers console_direct+` if you want to visualize all the output.
@@ -118,13 +118,13 @@ Add at the end the flags `--event-handlers console_direct+` if you want to visua
   ***Note: the graphs presented here are for demonstration purposes only. The data in the graphs are not meant to be accurate or current.***
 
 * Each test runs for **30** seconds with a **1k payload**, but this can be changed using CMake variables.
- - `PERF_TEST_MAX_RUNTIME`: Maximum number of seconds to run before  exiting. Zero runs forever.
+ - `PERF_TEST_RUNTIME`: Maximum number of seconds to run before  exiting. Zero runs forever.
  - `PERF_TEST_TOPIC`: Topic to use. These are all available topics: `Array1k`, `Array4k`, `Array16k`, `Array32k`, `Array60k`, `Array1m`, `Array2m`, `Struct16`, `Struct256`, `Struct4k`, `Struct32k`, `PointCloud512k`, `PointCloud1m`, `PointCloud2m`, `PointCloud4m`, `Range`, `NavSatFix`, `RadarDetection` and `RadarTrack`.
 
 For example, If we want to run the test during `30` seconds using the topic `Array1k`:
 
 ```bash
-colcon build --packages-select buildfarm_perf_tests --cmake-args -DPERF_TEST_MAX_RUNTIME="30" -DPERF_TEST_TOPIC="Array1k"
+colcon build --packages-select buildfarm_perf_tests --cmake-args -DPERF_TEST_RUNTIME="30" -DPERF_TEST_TOPIC="Array1k"
 ```
 
 * Each test produces a PNG plot of [various measures](http://build.ros2.org/view/Eci/job/Eci__nightly-performance_ubuntu_bionic_amd64/) across time, displayed in Jenkins using the image gallery plugin.


### PR DESCRIPTION
The name of the CMake variable is `PERF_TEST_RUNTIME`, not `PERF_TEST_MAX_RUNTIME`.
Also, there was a mistake in `colcon test` args, as `-DPERF_TEST_MAX_RUNTIME="30" -DPERF_TEST_TOPIC="Array1k"` are `colcon build --cmake-args` and do not affect the test (at least, not as they were mentioned there).