### PR TITLE
Target only Galactic in CI builds for galactic branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-    - master
+    - galactic
 
 jobs:
   build_and_test:
@@ -12,7 +12,7 @@ jobs:
     container: ${{matrix.container_image}}
     strategy:
       matrix:
-        container_image: ['ros:foxy', 'osrf/ros2:nightly-rmw-nonfree']
+        container_image: ['ros:galactic']
 
     steps:
     - name: Clone buildfarm_perf_tests

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # buildfarm perf tests
 
-[![Continuous Integration](https://github.com/ros2/buildfarm_perf_tests/workflows/Continuous%20Integration/badge.svg?branch=master&event=push)](https://github.com/ros2/buildfarm_perf_tests/actions?query=branch%3Amaster+event%3Apush)
+[![Continuous Integration](https://github.com/ros2/buildfarm_perf_tests/workflows/Continuous%20Integration/badge.svg?branch=galactic&event=push)](https://github.com/ros2/buildfarm_perf_tests/actions?query=branch%3Agalactic+event%3Apush)
 
 ## Purpose
 


### PR DESCRIPTION
Rolling targets the `master` branch, so we shouldn't try to build the `galactic` branch against it.