### PR TITLE
:farmer: fix: ament_target_dependencies() is deprecated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(rclcpp REQUIRED)
 add_executable(node_spinning src/node_spinning.cpp)
 target_link_libraries(
   node_spinning
-  "rclcpp"
+  rclcpp::rclcpp
 )
 
 install(TARGETS node_spinning


### PR DESCRIPTION
## Description

Buildfarm https://build.ros2.org/job/Rci__nightly-performance_ubuntu_noble_amd64/ have a CMake Warning that says
```
ament_target_dependencies() is deprecated. Use target_link_libraries()
```

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No generative AI used

### Additional Information

I made some changes in https://github.com/ros2/performance_test/pull/66 to fix this behaviour, also in this repo, I changed in `buildfarm_perf_tests/CMakeLists.txt`:

```diff
- ament_target_dependencies(
+ target_link_libraries(
-  "rclcpp"
+  rclcpp::rclcpp
```

Build Status:
[![Build Status](https://build.ros2.org/view/Rci/job/Rci__overlay_ubuntu_noble_amd64/badge/icon)](https://build.ros2.org/view/Rci/job/Rci__overlay_ubuntu_noble_amd64/)

CC: @Crola1702