### PR TITLE
Add RMW test fixture isolation to performance test templates

### DIFF
--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -22,6 +22,13 @@ import pandas as pd
 
 from rclpy import get_rmw_implementation_identifier
 
+from rmw_test_fixture_implementation import RMWTestIsolator
+import atexit
+
+_isolator = RMWTestIsolator()
+_isolator.__enter__()
+atexit.register(_isolator.__exit__, None, None, None)
+
 plt.switch_backend('agg')
 
 BYTE_TO_MBYTE = 1 / (1024*1024)

--- a/test/test_pub_sub.py.in
+++ b/test/test_pub_sub.py.in
@@ -21,6 +21,13 @@ import matplotlib.pyplot as plt
 import numpy as np  # noqa: F401
 import pandas as pd
 
+from rmw_test_fixture_implementation import RMWTestIsolator
+import atexit
+
+_isolator = RMWTestIsolator()
+_isolator.__enter__()
+atexit.register(_isolator.__exit__, None, None, None)
+
 plt.switch_backend('agg')
 
 

--- a/test/test_spinning.py.in
+++ b/test/test_spinning.py.in
@@ -27,6 +27,13 @@ import matplotlib.pyplot as plt
 import numpy as np  # noqa: F401
 import pandas as pd
 
+from rmw_test_fixture_implementation import RMWTestIsolator
+import atexit
+
+_isolator = RMWTestIsolator()
+_isolator.__enter__()
+atexit.register(_isolator.__exit__, None, None, None)
+
 plt.switch_backend('agg')
 
 


### PR DESCRIPTION
Fixes # (issue)

Fixes https://github.com/ros2/buildfarm_perf_tests/issues/116

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No
